### PR TITLE
Useid 311/apikey security layer get identity

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,3 +6,6 @@ api:
     - keyvalue: foobar
       refreshAddress: https://foobar.com
       dataGroups: [DG1,DG2]
+    - keyvalue: foobar2
+      refreshAddress: https://foobar2.com
+      dataGroups: [DG1,DG2, DG3]


### PR DESCRIPTION
`.onErrorReturn({ e -> e is SecurityException }, ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null))`
In order for us to handle/catch different error types in the subscriber chain, we can add a predicate in `onErrorReturn` which lets us specify the return value according to the error thrown. 
Due to the fact that the route is secured with an APIKey, we can easily read the dataGroups through the `authentication.details as ApiKeyDetails` and have a smooth and sound solution without adding a new parameter into the `IdentificationSession`

Let me know what you guys think of the solution. Tried to test everything accordingly. 
Cheers & have a nice weekend 🚀