### PR TITLE
USEID-392 Make refresh address passing same-origin-policy with subject URL

### DIFF
--- a/src/main/kotlin/de/bund/digitalservice/useid/refresh/RefreshController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/refresh/RefreshController.kt
@@ -19,10 +19,10 @@ class RefreshController(private val identificationSessionService: Identification
     private val log = KotlinLogging.logger {}
 
     @GetMapping
-    fun redirectService(@RequestParam sessionId: UUID): Mono<ResponseEntity<Unit>> {
-        return identificationSessionService.findByEIDSessionId(sessionId)
-            .doOnError { exception ->
-                log.error { "error occurred while checking $sessionId;\n ${exception.message}" }
+    fun redirectToEServiceRefreshAddress(@RequestParam("sessionId") eIDSessionId: UUID): Mono<ResponseEntity<Unit>> {
+        return identificationSessionService.findByEIDSessionId(eIDSessionId)
+            .doOnError {
+                log.error("Failed to load identification session with eIDSessionId: $eIDSessionId", it)
             }
             .map {
                 ResponseEntity

--- a/src/main/kotlin/de/bund/digitalservice/useid/refresh/RefreshController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/refresh/RefreshController.kt
@@ -1,0 +1,38 @@
+package de.bund.digitalservice.useid.refresh
+
+import de.bund.digitalservice.useid.identification.IdentificationSessionService
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+import java.net.URI
+import java.util.UUID
+
+@RestController
+@RequestMapping("/refresh")
+class RefreshController(private val identificationSessionService: IdentificationSessionService) {
+
+    private val log = KotlinLogging.logger {}
+
+    @GetMapping
+    fun redirectService(@RequestParam sessionId: UUID): Mono<ResponseEntity<Unit>> {
+        return identificationSessionService.findByEIDSessionId(sessionId)
+            .doOnError { exception ->
+                log.error { "error occurred while checking $sessionId;\n ${exception.message}" }
+            }
+            .map {
+                ResponseEntity
+                    .status(HttpStatus.SEE_OTHER)
+                    .location(URI.create(it.refreshAddress))
+                    .build<Unit>()
+            }
+            .defaultIfEmpty(ResponseEntity.status(HttpStatus.NOT_FOUND).build())
+            .onErrorReturn(
+                ResponseEntity.internalServerError().build()
+            )
+    }
+}

--- a/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 private const val AUTHORIZATION_HEADER = "Bearer some-api-key"
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Tag("test")
+@Tag("integration")
 class RefreshControllerIntegrationTest(@Autowired val webTestClient: WebTestClient) {
 
     @BeforeAll

--- a/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
@@ -5,6 +5,8 @@ import de.governikus.autent.sdk.eidservice.tctoken.TCTokenType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.unmockkAll
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -24,6 +26,11 @@ class RefreshControllerIntegrationTest(@Autowired val webTestClient: WebTestClie
     @BeforeAll
     fun setup() {
         mockkConstructor(EidService::class)
+    }
+
+    @AfterAll
+    fun afterTests() {
+        unmockkAll()
     }
 
     @Test
@@ -53,6 +60,9 @@ class RefreshControllerIntegrationTest(@Autowired val webTestClient: WebTestClie
             .exchange()
             .expectStatus()
             .is3xxRedirection
+            .expectHeader()
+            // "some-refresh-address" value is defined in the test application.yaml
+            .location("some-refresh-address")
     }
 
     @Test

--- a/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
@@ -1,0 +1,67 @@
+package de.bund.digitalservice.useid.refresh
+
+import de.bund.digitalservice.useid.eidservice.EidService
+import de.governikus.autent.sdk.eidservice.tctoken.TCTokenType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpHeaders
+import org.springframework.test.web.reactive.server.WebTestClient
+import java.net.URI
+import java.util.UUID
+
+private const val AUTHORIZATION_HEADER = "Bearer some-api-key"
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Tag("test")
+class RefreshControllerIntegrationTest(@Autowired val webTestClient: WebTestClient) {
+
+    @BeforeAll
+    fun setup() {
+        mockkConstructor(EidService::class)
+    }
+
+    @Test
+    fun `refresh endpoint redirect client to correct refresh address when eidSessionId is valid`() {
+        var tcTokenURL = ""
+        val eIdSessionId = UUID.randomUUID()
+        val mockTCToken = mockk<TCTokenType>()
+
+        every { anyConstructed<EidService>().getTcToken(any()) } returns mockTCToken
+        every { mockTCToken.refreshAddress } returns "https://www.foobar.com?sessionId=$eIdSessionId"
+
+        webTestClient
+            .post()
+            .uri("/api/v1/identification/sessions")
+            .headers { it.set(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER) }
+            .exchange()
+            .expectBody().jsonPath("$.tcTokenUrl").value<String> { tcTokenURL = it }
+
+        webTestClient
+            .get()
+            .uri(URI.create(tcTokenURL).rawPath)
+            .exchange()
+
+        webTestClient
+            .get()
+            .uri("/refresh?sessionId=$eIdSessionId")
+            .exchange()
+            .expectStatus()
+            .is3xxRedirection
+    }
+
+    @Test
+    fun `refresh endpoint responds with status code 404 when eidSessionId is invalid`() {
+        webTestClient
+            .get()
+            .uri("/refresh?sessionId=${UUID.randomUUID()}")
+            .exchange()
+            .expectStatus()
+            .isNotFound
+    }
+}

--- a/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/refresh/RefreshControllerIntegrationTest.kt
@@ -27,7 +27,7 @@ class RefreshControllerIntegrationTest(@Autowired val webTestClient: WebTestClie
     }
 
     @Test
-    fun `refresh endpoint redirect client to correct refresh address when eidSessionId is valid`() {
+    fun `refresh endpoint redirects client to correct refresh address when eidSessionId is valid`() {
         var tcTokenURL = ""
         val eIdSessionId = UUID.randomUUID()
         val mockTCToken = mockk<TCTokenType>()


### PR DESCRIPTION
## Problem
Since the technical guideline describes, that refresh address should respect same origin policy, therefor we cannot use eService address directly.

## Proposed changes
1. Add `/refresh` endpoint as a proxy