### PR TITLE
Useid 578/widget tracking

### DIFF
--- a/src/main/kotlin/de/bund/digitalservice/useid/tracking/TrackingProperties.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/tracking/TrackingProperties.kt
@@ -1,0 +1,17 @@
+package de.bund.digitalservice.useid.tracking
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
+import javax.validation.constraints.NotBlank
+
+@Component
+@ConfigurationProperties(prefix = "tracking")
+@Validated
+class TrackingProperties {
+    @NotBlank
+    lateinit var matomoSiteId: String
+
+    @NotBlank
+    lateinit var matomoDomain: String
+}

--- a/src/main/kotlin/de/bund/digitalservice/useid/tracking/TrackingService.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/tracking/TrackingService.kt
@@ -1,0 +1,35 @@
+package de.bund.digitalservice.useid.tracking
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+@Service
+class TrackingService(private val trackingProperties: TrackingProperties) {
+
+    private val log = KotlinLogging.logger {}
+    private val httpClient: HttpClient = HttpClient.newBuilder().build()
+    private val responseHandler: HttpResponse.BodyHandler<String> = HttpResponse.BodyHandlers.ofString()
+
+    private fun sendTrackingRequest(url: String) {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .build()
+
+        val response = httpClient.send(request, responseHandler)
+        val status = response.statusCode()
+        if (status != 200) {
+            log.error("$status, tracking failed for: $url")
+        }
+        log.info("$status, successfully tracked: $url")
+    }
+
+    fun sendMatomoEvent(category: String, action: String, name: String) {
+        val matomoSiteId = trackingProperties.matomoSiteId
+        val domain = trackingProperties.matomoDomain
+        sendTrackingRequest("$domain?idsite=$matomoSiteId&rec=1&ca=1&e_c=$category&e_a=$action&e_n=$name")
+    }
+}

--- a/src/main/kotlin/de/bund/digitalservice/useid/tracking/WidgetTracking.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/tracking/WidgetTracking.kt
@@ -1,0 +1,29 @@
+package de.bund.digitalservice.useid.tracking
+
+import org.springframework.stereotype.Component
+
+@Component
+class WidgetTracking {
+
+    class Categories {
+        val widget = "Widget"
+    }
+
+    class Actions {
+        val loaded = "loaded"
+        val buttonPressed = "buttonPressed"
+        val error = "error"
+    }
+
+    class Names {
+        val widget = "widget"
+        val startIdent = "startIdent"
+        val incompatible = "incompatible"
+        val unsupported_os = "unsupported_os"
+        val fallback = "fallback"
+    }
+
+    val categories = Categories()
+    val actions = Actions()
+    val names = Names()
+}

--- a/src/main/kotlin/de/bund/digitalservice/useid/tracking/WidgetTracking.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/tracking/WidgetTracking.kt
@@ -19,7 +19,7 @@ class WidgetTracking {
         val widget = "widget"
         val startIdent = "startIdent"
         val incompatible = "incompatible"
-        val unsupported_os = "unsupported_os"
+        val unsupportedOS = "unsupportedOS"
         val fallback = "fallback"
     }
 

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -1,6 +1,8 @@
 package de.bund.digitalservice.useid.widget
 
 import de.bund.digitalservice.useid.config.ApplicationProperties
+import de.bund.digitalservice.useid.tracking.TrackingService
+import de.bund.digitalservice.useid.tracking.WidgetTracking
 import io.micrometer.core.annotation.Timed
 import org.springframework.http.HttpStatus
 import org.springframework.http.server.reactive.ServerHttpRequest
@@ -17,7 +19,9 @@ internal const val FALLBACK_PAGE = "eID-Client"
 @Timed
 class WidgetController(
     private val applicationProperties: ApplicationProperties,
-    private val widgetProperties: WidgetProperties
+    private val widgetProperties: WidgetProperties,
+    private val trackingService: TrackingService,
+    private val widgetTracking: WidgetTracking
 ) {
     private val defaultViewHeaderConfig = mapOf(
         "baseUrl" to applicationProperties.baseUrl,
@@ -26,6 +30,12 @@ class WidgetController(
 
     @GetMapping("/$WIDGET_PAGE")
     fun getWidgetPage(model: Model): Rendering {
+        trackingService.sendMatomoEvent(
+            widgetTracking.categories.widget,
+            widgetTracking.actions.loaded,
+            widgetTracking.names.widget
+        )
+
         val widgetViewConfig = mapOf(
             setMainViewLocalization(),
             setMainViewMobileURL(),
@@ -42,6 +52,12 @@ class WidgetController(
 
     @GetMapping("/$INCOMPATIBLE_PAGE")
     fun getIncompatiblePage(model: Model): Rendering {
+        trackingService.sendMatomoEvent(
+            widgetTracking.categories.widget,
+            widgetTracking.actions.loaded,
+            widgetTracking.names.incompatible
+        )
+
         val incompatibleViewConfig = mapOf(
             "localization" to widgetProperties.errorView.incompatible.localization
         )
@@ -55,6 +71,11 @@ class WidgetController(
 
     @GetMapping("/$FALLBACK_PAGE")
     fun getUniversalLinkFallbackPage(model: Model, serverHttpRequest: ServerHttpRequest): Rendering {
+        trackingService.sendMatomoEvent(
+            widgetTracking.categories.widget,
+            widgetTracking.actions.loaded,
+            widgetTracking.names.fallback
+        )
         /*
             Documentation about the link syntax can be found in
             Technical Guideline TR-03124-1 – eID-Client, Part 1: Specifications Version 1.4 8. October 2021

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -16,7 +16,7 @@ import org.springframework.web.reactive.result.view.Rendering
 internal const val WIDGET_PAGE = "widget"
 internal const val INCOMPATIBLE_PAGE = "incompatible"
 internal const val FALLBACK_PAGE = "eID-Client"
-internal const val APP_OPENED = "app-opened"
+internal const val WIDGET_START_IDENT_BTN_CLICKED = "start-ident-button-clicked"
 
 @Controller
 @Timed
@@ -31,7 +31,16 @@ class WidgetController(
         "metaTag" to widgetProperties.metaTag
     )
 
-    @PostMapping("/$APP_OPENED")
+    // ASYNC WITH GLOBAL SCOPE
+    // GlobalScope.async {
+    //     trackingService.sendMatomoEvent(
+    //         widgetTracking.categories.widget,
+    //         widgetTracking.actions.buttonPressed,
+    //         widgetTracking.names.startIdent
+    //     )
+    // }
+
+    @PostMapping("/$WIDGET_START_IDENT_BTN_CLICKED")
     fun handleAppOpened(): ResponseEntity<String> {
         trackingService.sendMatomoEvent(
             widgetTracking.categories.widget,

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -5,15 +5,18 @@ import de.bund.digitalservice.useid.tracking.TrackingService
 import de.bund.digitalservice.useid.tracking.WidgetTracking
 import io.micrometer.core.annotation.Timed
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.reactive.result.view.Rendering
 
 internal const val WIDGET_PAGE = "widget"
 internal const val INCOMPATIBLE_PAGE = "incompatible"
 internal const val FALLBACK_PAGE = "eID-Client"
+internal const val APP_OPENED = "app-opened"
 
 @Controller
 @Timed
@@ -27,6 +30,16 @@ class WidgetController(
         "baseUrl" to applicationProperties.baseUrl,
         "metaTag" to widgetProperties.metaTag
     )
+
+    @PostMapping("/$APP_OPENED")
+    fun handleAppOpened(): ResponseEntity<String> {
+        trackingService.sendMatomoEvent(
+            widgetTracking.categories.widget,
+            widgetTracking.actions.buttonPressed,
+            widgetTracking.names.startIdent
+        )
+        return ResponseEntity.status(HttpStatus.OK).body("")
+    }
 
     @GetMapping("/$WIDGET_PAGE")
     fun getWidgetPage(model: Model): Rendering {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,6 +70,10 @@ csp:
   default-config: "default-src 'self';script-src 'self';style-src 'self';font-src 'self';img-src 'self';connect-src 'self';"
   frame-ancestors: "frame-ancestors 'self'"
 
+tracking:
+  matomo-site-id: # set via environment
+  matomo-domain: # set via environment
+
 widget:
   meta-tag:
     header-title: DigitalService GmbH des Bundes

--- a/src/main/resources/static/js/attachButtonTracking.js
+++ b/src/main/resources/static/js/attachButtonTracking.js
@@ -1,7 +1,9 @@
-document.getElementById("eid-client-button").addEventListener("click", async function () {
-    await fetch('/app-opened', {
-        cache: "no-store",
-        method: "POST",
-        keepalive: true
+document
+  .getElementById("eid-client-button")
+  .addEventListener("click", async function () {
+    await fetch("/app-opened", {
+      cache: "no-store",
+      method: "POST",
+      keepalive: true,
     });
-});
+  });

--- a/src/main/resources/static/js/attachButtonTracking.js
+++ b/src/main/resources/static/js/attachButtonTracking.js
@@ -1,0 +1,7 @@
+document.getElementById("eid-client-button").addEventListener("click", async function () {
+    await fetch('/app-opened', {
+        cache: "no-store",
+        method: "POST",
+        keepalive: true
+    });
+});

--- a/src/main/resources/static/js/attachStartIdentButtonOnClick.js
+++ b/src/main/resources/static/js/attachStartIdentButtonOnClick.js
@@ -1,7 +1,7 @@
 document
   .getElementById("eid-client-button")
   .addEventListener("click", async function () {
-    await fetch("/app-opened", {
+    await fetch("/start-ident-button-clicked", {
       cache: "no-store",
       method: "POST",
       keepalive: true,

--- a/src/main/resources/templates/widget.mustache
+++ b/src/main/resources/templates/widget.mustache
@@ -38,7 +38,7 @@
             </a>
         </div>
     </div>
-    <script type="text/javascript" src="js/attachButtonTracking.js"></script>
+    <script type="text/javascript" src="js/attachStartIdentButtonOnClick.js"></script>
     {{#isWidget}}
         <script type="text/javascript" src="js/identifyHandler.js"></script>
     {{/isWidget}}

--- a/src/main/resources/templates/widget.mustache
+++ b/src/main/resources/templates/widget.mustache
@@ -38,6 +38,7 @@
             </a>
         </div>
     </div>
+    <script type="text/javascript" src="js/attachButtonTracking.js"></script>
     {{#isWidget}}
         <script type="text/javascript" src="js/identifyHandler.js"></script>
     {{/isWidget}}

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -115,7 +115,7 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
     fun `widget endpoint APP_OPENED should return 200`() {
         webTestClient
             .post()
-            .uri("/$APP_OPENED")
+            .uri("/$WIDGET_START_IDENT_BTN_CLICKED")
             .exchange()
             .expectStatus().isOk
     }

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -1,8 +1,12 @@
 package de.bund.digitalservice.useid.widget
 
+import com.ninjasquad.springmockk.MockkBean
+import de.bund.digitalservice.useid.tracking.TrackingService
 import de.bund.digitalservice.useid.util.PostgresTestcontainerIntegrationTest
+import io.mockk.every
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -13,6 +17,14 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
 
     @Autowired
     private lateinit var widgetProperties: WidgetProperties
+
+    @MockkBean
+    private lateinit var trackingService: TrackingService
+
+    @BeforeEach
+    fun setup() {
+        every { trackingService.sendMatomoEvent(any(), any(), any()) } returns Unit
+    }
 
     @Test
     fun `widget endpoint should disable X-Frame-Options`() {
@@ -72,7 +84,7 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
     }
 
     @Test
-    fun `widget endpoint INCOMPATIBLE_PAGE should return 200`() {
+    fun `widget endpoint INCOMPATIBLE_PAGE should return 200 and should contain headlineTitle`() {
         val result = webTestClient
             .get()
             .uri("/$INCOMPATIBLE_PAGE")
@@ -86,7 +98,7 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
     }
 
     @Test
-    fun `widget endpoint FALLBACK_PAGE should return 200`() {
+    fun `widget endpoint FALLBACK_PAGE should return 200 and should contain errorTitle`() {
         val result = webTestClient
             .get()
             .uri("/$FALLBACK_PAGE")
@@ -97,5 +109,15 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
 
         val body = String(result.responseBody!!)
         assertThat(body, containsString(widgetProperties.errorView.fallback.localization.errorTitle))
+    }
+
+    @Test
+    fun `widget endpoint APP_OPENED should return 200`() {
+
+        webTestClient
+            .post()
+            .uri("/$APP_OPENED")
+            .exchange()
+            .expectStatus().isOk
     }
 }

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -113,7 +113,6 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
 
     @Test
     fun `widget endpoint APP_OPENED should return 200`() {
-
         webTestClient
             .post()
             .uri("/$APP_OPENED")

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -47,6 +47,10 @@ csp:
     - foo.bar
     - bar.foo
 
+tracking:
+  matomo-site-id: "1"
+  matomo-domain: "https://matomo-server/matomo.php"
+
 widget:
   meta-tag:
     header-title: DigitalService GmbH des Bundes


### PR DESCRIPTION
Calls are fired and you can check the events on [Matomo Live](https://bund.matomo.cloud/index.php?module=CoreHome&action=index&idSite=2&period=range&date=last30#?idSite=2&period=range&date=last30&category=General_Visitors&subcategory=General_RealTime) and [Matomo Events](https://bund.matomo.cloud/index.php?module=CoreHome&action=index&idSite=2&period=range&date=last30#?idSite=2&period=range&date=last30&category=General_Actions&subcategory=Events_Events). Widget also tracks Button Pressed event and calls backend route /app-openend. 

![image](https://user-images.githubusercontent.com/29574225/197569043-f264fc6f-00b8-4efc-8430-e742dd77887d.png)

Implementing the service and the matomo events, I'v realized that we are not having the WidgetController Routes in Reactive Style. Should I rework these routes to be reactive? 
I would vote for yes. (but I'd do this directly on main. PRs suck)
Please let me know @mpanne @code28 

Also I am unsure about how much testing the tracking needs... Please share your thoughts about it! 


