### PR TITLE
Removing vertical padding around the whole widget

### DIFF
--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -206,7 +206,3 @@ h2 {
 .incompatible-notification__wrapper li p:first-child {
     font-weight: 700;
 }
-
-.widget.incompatible {
-    padding: 48px 0 48px 0;
-}


### PR DESCRIPTION
Service providers such as Grundsteuer already have implemented the necessary vertical spacing around the widget.