### PR TITLE
Error headline → smaller + black

### DIFF
--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -179,8 +179,8 @@ h2 {
     margin-bottom: 16px;
 }
 .incompatible-notification__wrapper h1 {
-    color: #004b76;
-    font-size: 1.5rem;
+    color: #0b0c0c;
+    font-size: 1.25rem;
     font-weight: 700;
     line-height: 1.3;
     margin-bottom: 12px;


### PR DESCRIPTION
Goal: Text color consistency and making the longer text better readable on small devices.