### PR TITLE
Useid 656/patch versions of transitive dependencies to address vulnerabilities

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,13 +2,3 @@
 # We are not affected: "This applies to applications that allow untrusted users to upload/modify velocity templates running Apache Velocity Engine"
 # See here: https://velocity.apache.org/news.html#CVE-2020-13936
 CVE-2020-13936
-
-# com.fasterxml.woodstox:woodstox-core:6.2.6
-# Ignore to fix the pipline until we found a solution. It is already deployed so ignoring won't make it worse.
-# TODO: Remove from ignore list
-CVE-2022-40153
-CVE-2022-40151
-CVE-2022-40156
-CVE-2022-40155
-CVE-2022-40154
-CVE-2022-40152

--- a/allowed-licenses.json
+++ b/allowed-licenses.json
@@ -52,10 +52,14 @@
       "moduleLicense": "CDDL+GPL"
     },
     {
-      "moduleLicense": "Dual license consisting of the CDDL v1.1 and GPL v2"
+      "moduleLicense": "\n                Dual license consisting of the CDDL v1.1 and GPL v2\n            "
     },
     {
       "moduleLicense": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1"
+    },
+    {
+      "moduleLicense": null,
+      "moduleName": "org.glassfish.ha:ha-api"
     },
     {
       "moduleLicense": null,

--- a/allowed-licenses.json
+++ b/allowed-licenses.json
@@ -46,6 +46,18 @@
       "moduleLicense": "CDDL + GPLv2 with classpath exception"
     },
     {
+      "moduleLicense": "Dual License: CDDL 1.0 and GPL V2 with Classpath Exception"
+    },
+    {
+      "moduleLicense": "CDDL+GPL"
+    },
+    {
+      "moduleLicense": "Dual license consisting of the CDDL v1.1 and GPL v2"
+    },
+    {
+      "moduleLicense": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1"
+    },
+    {
       "moduleLicense": null,
       "moduleName": "com.fasterxml.jackson:jackson-bom"
     },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,7 +201,7 @@ tasks {
         val containerImageVersion = System.getenv("CONTAINER_IMAGE_VERSION") ?: "latest"
 
         imageName = "$containerRegistry/$containerImageName:$containerImageVersion"
-        builder = "paketobuildpacks/builder:tiny" // pin to version 0.1.260-tiny
+        builder = "paketobuildpacks/builder:tiny"
         isPublish = false
 
         docker {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,8 +87,16 @@ dependencies {
     implementation("org.apache.santuario:xmlsec:3.0.0")
     // => CVE-2020-28052
     implementation("org.bouncycastle:bcprov-jdk15on:1.70")
-    // => CVE-2022-40153
+
+    // webservices-rt:2.6.7 includes woodstox-core:6.2.6 which has several known vulnerabilities
+    // --> updating webservices-rt to latest version
+    implementation("org.glassfish.metro:webservices-rt:4.0.1")
+    implementation("org.glassfish.metro:webservices-api:4.0.1")
+    // --> override version of woodstox-core to patch vulnerabilities
     implementation("com.fasterxml.woodstox:woodstox-core:6.4.0")
+    // --> include required packages to satisfy direct dependencies to old versions in code
+    implementation("javax.xml.ws:jaxws-api:2.3.1") // To obtain javax.xml.ws.BindingProvider
+    implementation("com.sun.xml.ws:rt:2.3.1")
 
     /** Development **/
     developmentOnly("org.springframework.boot:spring-boot-devtools")
@@ -193,7 +201,7 @@ tasks {
         val containerImageVersion = System.getenv("CONTAINER_IMAGE_VERSION") ?: "latest"
 
         imageName = "$containerRegistry/$containerImageName:$containerImageVersion"
-        builder = "paketobuildpacks/builder@sha256:0e0cdb719946ed6accc63da32f58e9853575b7b7e1b2110b08406d01809423ee" // pin to version 0.1.260-tiny
+        builder = "paketobuildpacks/builder:tiny" // pin to version 0.1.260-tiny
         isPublish = false
 
         docker {

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -89,11 +89,11 @@ class WidgetController(
             widgetTracking.names.fallback
         )
         /*
-            Documentation about the link syntax can be found in
-            Technical Guideline TR-03124-1 – eID-Client, Part 1: Specifications Version 1.4 8. October 2021
-            Chapter 2.2 Full eID-Client
+            Documentation about the link syntax can be found in Technical Guideline TR-03124-1 – eID-Client, Part 1:
+            Specifications Version 1.4 8. October 2021, Chapter 2.2 Full eID-Client
+            Note: Replaced the prefix eid:// with bundesident:// to make sure only the BundesIdent app is opened
          */
-        val url = "eid://127.0.0.1:24727/eID-Client?${serverHttpRequest.uri.rawQuery}"
+        val url = "bundesident://127.0.0.1:24727/eID-Client?${serverHttpRequest.uri.rawQuery}"
 
         val widgetViewConfig = mapOf(
             setMainViewLocalization(),

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -89,11 +89,11 @@ class WidgetController(
             widgetTracking.names.fallback
         )
         /*
-            Documentation about the link syntax can be found in Technical Guideline TR-03124-1 – eID-Client, Part 1:
-            Specifications Version 1.4 8. October 2021, Chapter 2.2 Full eID-Client
-            Note: Replaced the prefix eid:// with bundesident:// to make sure only the BundesIdent app is opened
+            Documentation about the link syntax can be found in
+            Technical Guideline TR-03124-1 – eID-Client, Part 1: Specifications Version 1.4 8. October 2021
+            Chapter 2.2 Full eID-Client
          */
-        val url = "bundesident://127.0.0.1:24727/eID-Client?${serverHttpRequest.uri.rawQuery}"
+        val url = "eid://127.0.0.1:24727/eID-Client?${serverHttpRequest.uri.rawQuery}"
 
         val widgetViewConfig = mapOf(
             setMainViewLocalization(),


### PR DESCRIPTION
Our nested dependency `webservices-rt:2.6.7` includes the package `woodstox-core:6.2.6` which is not detected by Gradle since it is not stated in the `pom.xml` but the resulting `JAR` still includes it. The version 6.2.6 of the package has 5 known vulnerabilities. Since Gradle does not detect it as transitive dependency, we cannot just bump the version of `woodstox-core` but need to update `webservices-rt`. This results in some missing required classes which is why we need to include some other xml dependencies. 