### PR TITLE
Add padding to widget fallback page

### DIFF
--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -52,7 +52,8 @@ class WidgetController(
             setMainViewLocalization(),
             setMainViewMobileURL(),
             setEiDClientURL("#"),
-            "isWidget" to true
+            "isWidget" to true,
+            "additionalClass" to ""
         )
 
         return Rendering
@@ -99,7 +100,8 @@ class WidgetController(
             setMainViewLocalization(),
             setMainViewMobileURL(),
             setEiDClientURL(url),
-            "localizationError" to widgetProperties.errorView.fallback.localization
+            "localizationError" to widgetProperties.errorView.fallback.localization,
+            "additionalClass" to "fallback"
         )
 
         return Rendering

--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -163,7 +163,7 @@ h2 {
     max-width: 400px;
 }
 .widget.fallback {
-    padding: 1rem;
+    padding: 4vw;
 }
 
 /*INCOMPATIBLE PAGE*/

--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -162,6 +162,9 @@ h2 {
 .widget {
     max-width: 400px;
 }
+.widget.fallback {
+    padding: 1rem;
+}
 
 /*INCOMPATIBLE PAGE*/
 .incompatible-notification__wrapper {

--- a/src/main/resources/templates/widget.mustache
+++ b/src/main/resources/templates/widget.mustache
@@ -1,5 +1,5 @@
 {{>layout/header}}
-    <div class="container widget">
+    <div class="container widget {{additionalClass}}">
         {{#localizationError}}
             {{>components/errorNotification}}
         {{/localizationError}}

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -109,6 +109,7 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
 
         val body = String(result.responseBody!!)
         assertThat(body, containsString(widgetProperties.errorView.fallback.localization.errorTitle))
+        assertThat(body, containsString("class=\"container widget fallback\""))
     }
 
     @Test


### PR DESCRIPTION
Add some padding to the fallback widget page since it is always opened in a new tab without a surrounding container.