### PR TITLE
USEID-572: incompatible OS page info

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,6 +93,9 @@ dependencies {
     // => CVE-2022-40153
     implementation("com.fasterxml.woodstox:woodstox-core:6.4.0")
 
+    /** Helpers **/
+    implementation("com.github.ua-parser:uap-java:1.5.3")
+
     /** Development **/
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -146,12 +146,6 @@ class WidgetController(
         return "eidClientURL" to url
     }
 
-    /*
-       Since user agent will return version in String, we need to properly convert the string to integer,
-       otherwise we cannot perform logical operations such as <= or >=
-       If major version returns empty or somehow the user agent parser cannot parse the version properly,
-       we will show to users the widget
-    */
 
     private fun isIncompatibleOSVersion(userAgent: String): Boolean {
         val parsedUserAgent = Parser().parse(userAgent)

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -155,8 +155,8 @@ class WidgetController(
 
     private fun isIncompatibleOSVersion(userAgent: String): Boolean {
         val parsedUserAgent = Parser().parse(userAgent)
-        val incompatibleIOSVersion = hasIncompatibleMajorVersion(parsedUserAgent, "iOS", 14)
-        val incompatibleAndroidVersion = hasIncompatibleMajorVersion(parsedUserAgent, "Android", 8)
+        val incompatibleIOSVersion = hasIncompatibleMajorVersion(parsedUserAgent, "iOS", 15)
+        val incompatibleAndroidVersion = hasIncompatibleMajorVersion(parsedUserAgent, "Android", 9)
 
         return incompatibleIOSVersion || incompatibleAndroidVersion
     }
@@ -164,6 +164,6 @@ class WidgetController(
     private fun hasIncompatibleMajorVersion(parsedUserAgent: Client, osFamily: String, supportedMajorVersion: Int): Boolean {
         return parsedUserAgent.os.family == osFamily &&
             !parsedUserAgent.os.major.isNullOrEmpty() &&
-            Integer.parseInt(parsedUserAgent.os.major) <= supportedMajorVersion
+            Integer.parseInt(parsedUserAgent.os.major) < supportedMajorVersion
     }
 }

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -66,8 +66,9 @@ class WidgetController(
         val parsedUserAgent = Parser().parse(userAgent)
         val incompatibleIOSVersion = hasIncompatibleMajorVersion(parsedUserAgent, "iOS", 14)
         val incompatibleAndroidVersion = hasIncompatibleMajorVersion(parsedUserAgent, "Android", 8)
+        val isIncompatibleOSVersion = incompatibleIOSVersion || incompatibleAndroidVersion
 
-        if (incompatibleIOSVersion || incompatibleAndroidVersion) {
+        if (isIncompatibleOSVersion) {
             return Rendering
                 .redirectTo("/$INCOMPATIBLE_PAGE")
                 .build()

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -151,17 +151,10 @@ class WidgetController(
        If major version returns empty or somehow the user agent parser cannot parse the version properly,
        we will show to users the widget
     */
-    private fun safelyGetMajorOSVersion(majorVersion: String?): Int? {
-        return try {
-            Integer.parseInt(majorVersion)
-        } catch (exception: NumberFormatException) {
-            null
-        }
-    }
 
     private fun hasIncompatibleMajorVersion(parsedUserAgent: Client, osFamily: String, supportedMajorVersion: Int): Boolean {
         return parsedUserAgent.os.family == osFamily &&
-            parsedUserAgent.os.major != null &&
-            safelyGetMajorOSVersion(parsedUserAgent.os.major)!! <= supportedMajorVersion
+            !parsedUserAgent.os.major.isNullOrEmpty() &&
+            Integer.parseInt(parsedUserAgent.os.major) <= supportedMajorVersion
     }
 }

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -150,12 +150,12 @@ class WidgetController(
        we will show to users the widget
     */
     private fun safelyGetMajorOSVersion(majorVersion: String?): Int {
-        val defaultOSVersion = 20
+        val fallbackOSVersion = 20
 
         return try {
             Integer.parseInt(majorVersion)
         } catch (exception: NumberFormatException) {
-            defaultOSVersion
+            fallbackOSVersion
         }
     }
 }

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -63,16 +63,8 @@ class WidgetController(
             "additionalClass" to ""
         )
 
-        try {
-            if (isIncompatibleOSVersion(userAgent)) {
-                return Rendering.redirectTo("/$INCOMPATIBLE_PAGE").build()
-            }
-        } catch (exception: Exception) {
-            return Rendering
-                .view(WIDGET_PAGE)
-                .model(defaultViewHeaderConfig + widgetViewConfig)
-                .status(HttpStatus.OK)
-                .build()
+        if (isIncompatibleOSVersion(userAgent)) {
+            return Rendering.redirectTo("/$INCOMPATIBLE_PAGE").build()
         }
 
         return Rendering
@@ -146,13 +138,16 @@ class WidgetController(
         return "eidClientURL" to url
     }
 
-
     private fun isIncompatibleOSVersion(userAgent: String): Boolean {
-        val parsedUserAgent = Parser().parse(userAgent)
-        val incompatibleIOSVersion = hasIncompatibleMajorVersion(parsedUserAgent, "iOS", 15)
-        val incompatibleAndroidVersion = hasIncompatibleMajorVersion(parsedUserAgent, "Android", 9)
+        return try {
+            val parsedUserAgent = Parser().parse(userAgent)
+            val incompatibleIOSVersion = hasIncompatibleMajorVersion(parsedUserAgent, "iOS", 15)
+            val incompatibleAndroidVersion = hasIncompatibleMajorVersion(parsedUserAgent, "Android", 9)
 
-        return incompatibleIOSVersion || incompatibleAndroidVersion
+            incompatibleIOSVersion || incompatibleAndroidVersion
+        } catch (exception: Exception) {
+            false
+        }
     }
 
     private fun hasIncompatibleMajorVersion(parsedUserAgent: Client, osFamily: String, supportedMajorVersion: Int): Boolean {

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -64,8 +64,8 @@ class WidgetController(
         )
 
         val parsedUserAgent = Parser().parse(userAgent)
-        val incompatibleIOSVersion = hasSupportedMajorOSVersion(parsedUserAgent, "iOS", 14)
-        val incompatibleAndroidVersion = hasSupportedMajorOSVersion(parsedUserAgent, "Android", 8)
+        val incompatibleIOSVersion = hasIncompatibleMajorVersion(parsedUserAgent, "iOS", 14)
+        val incompatibleAndroidVersion = hasIncompatibleMajorVersion(parsedUserAgent, "Android", 8)
 
         if (incompatibleIOSVersion || incompatibleAndroidVersion) {
             return Rendering
@@ -158,7 +158,7 @@ class WidgetController(
         }
     }
 
-    private fun hasSupportedMajorOSVersion(parsedUserAgent: Client, osFamily: String, supportedMajorVersion: Int): Boolean {
+    private fun hasIncompatibleMajorVersion(parsedUserAgent: Client, osFamily: String, supportedMajorVersion: Int): Boolean {
         return parsedUserAgent.os.family == osFamily &&
             parsedUserAgent.os.major != null &&
             safelyGetMajorOSVersion(parsedUserAgent.os.major)!! <= supportedMajorVersion

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetTracking.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetTracking.kt
@@ -18,8 +18,7 @@ class WidgetTracking {
     class Names {
         val widget = "widget"
         val startIdent = "startIdent"
-        val incompatible = "incompatible"
-        val unsupportedOS = "unsupportedOS"
+        val incompatible = "unsupportedOS"
         val fallback = "fallback"
     }
 

--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -94,7 +94,7 @@ h2 {
 .container {
     width: 100%;
 }
-.container.fallback {
+.container.fallback, .container.incompatible {
     padding: 4vw;
 }
 .headline {
@@ -167,7 +167,7 @@ h2 {
 }
 
 /*INCOMPATIBLE PAGE*/
-.incompatible {
+.incompatible > .widget {
     margin-top: 65px;
 }
 .incompatible-notification__wrapper {

--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -167,6 +167,9 @@ h2 {
 }
 
 /*INCOMPATIBLE PAGE*/
+.incompatible {
+    margin-top: 65px;
+}
 .incompatible-notification__wrapper {
     background-color: #f2f6f8;
     color: #333;

--- a/src/main/resources/templates/incompatible.mustache
+++ b/src/main/resources/templates/incompatible.mustache
@@ -1,5 +1,6 @@
 {{>layout/header}}
-    <div class="container widget incompatible">
+<div class="container incompatible">
+    <div class="widget">
         <div class="incompatible-notification__wrapper">
             <img src="images/widget-incompatible.svg" alt="image of device" />
             <h1>{{localization.headlineTitle}}</h1>
@@ -16,4 +17,5 @@
             </ul>
         </div>
     </div>
+</div>
 {{>layout/footer}}

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -72,6 +72,54 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
     }
 
     @Test
+    fun `widget endpoint renders page correctly when the devices are supported`() {
+        val compatibleAndroidUserAgent = "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.5304.105 Mobile Safari/537.36"
+        val compatibleIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Mobile/15E148 Safari/604.1"
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", compatibleAndroidUserAgent)
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", compatibleIOSUserAgent)
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
+    fun `widget endpoint redirects to INCOMPATIBLE_PAGE when the devices are unsupported`() {
+        val incompatibleAndroidUserAgent = "Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30"
+        val incompatibleIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1"
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", incompatibleAndroidUserAgent)
+            .exchange()
+            .expectHeader()
+            .location("/incompatible")
+            .expectStatus()
+            .is3xxRedirection
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", incompatibleIOSUserAgent)
+            .exchange()
+            .expectHeader()
+            .location("/incompatible")
+            .expectStatus()
+            .is3xxRedirection
+    }
+
+    @Test
     fun `widget endpoint INCOMPATIBLE_PAGE should return 200 and should contain headlineTitle`() {
         val result = webTestClient
             .get()

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -94,6 +94,26 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
     }
 
     @Test
+    fun `widget endpoint renders widget page correctly when the user agents do not have proper OS version`() {
+        val malformedAndroidUserAgent = "Mozilla/5.0 (Linux; Android) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.5304.105 Mobile Safari/537.36"
+        val malformedIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1"
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", malformedAndroidUserAgent)
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", malformedIOSUserAgent)
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
     fun `widget endpoint redirects to INCOMPATIBLE_PAGE when the devices are unsupported`() {
         val incompatibleAndroidUserAgent = "Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30"
         val incompatibleIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1"

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -114,6 +114,30 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
             .expectStatus()
             .isOk
     }
+
+    @Test
+    fun `widget endpoint renders widget page correctly when the user agents are malformed`() {
+        val malformedAndroidUserAgent = "Android Foo Bar"
+        val malformedIOSUserAgent = "iPhone Foo Bar"
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", malformedAndroidUserAgent)
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        webTestClient
+            .get()
+            .uri("/widget")
+            .header("User-Agent", malformedIOSUserAgent)
+            .exchange()
+            .expectStatus()
+            .isOk
+    }
+
+    @Test
     fun `widget endpoint redirects to INCOMPATIBLE_PAGE when the devices are unsupported`() {
         val incompatibleAndroidUserAgent = "Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30"
         val incompatibleIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1"

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -107,8 +107,8 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
 
     @Test
     fun `widget endpoint redirects to INCOMPATIBLE_PAGE when the devices are unsupported`() {
-        val incompatibleAndroidUserAgent = "Mozilla/5.0 (Linux; U; Android 4.0.2; en-us; Galaxy Nexus Build/ICL53F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30"
-        val incompatibleIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1"
+        val incompatibleAndroidUserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; SM-G960F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36"
+        val incompatibleIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
 
         val (iosResponse, androidResponse) = fetchWidgetPageWithMobileDevices(incompatibleAndroidUserAgent, incompatibleIOSUserAgent)
 


### PR DESCRIPTION
# Problem
User cannot see directly which OS version is supported

# Proposed changes
1. Add user agent library `com.github.ua-parser:uap-java:1.5.3` . it is lightweight and the API for OS version is simpler than other candidate. This library breaks down the versioning into 3 properties (major, minor and patch) where other libraries do not.
2. Safely convert the version from the parser, since the parser will return a String, we need to transform the String into an Integer so that we can perform logical operation (>= or <=), so we need to safely cast it, in case of missing version number or unknown OS version, we show the widget instead (still need a product decision) 
3. Add 4 test cases where the string of
- User agent is correct
- User agent has no version
- User agent is incorrect
- User agent with unsupported version
4. Fix the incompatible page. The top area is out of view. 
![image](https://user-images.githubusercontent.com/9930966/202505861-4ce592a7-aa01-481a-b2de-791f3fcdf875.png)

