### PR TITLE
USEID-608: Ensure accessibility of the widget

### DIFF
--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetProperties.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetProperties.kt
@@ -74,7 +74,13 @@ class WidgetProperties {
             lateinit var identificationButton: String
 
             @NotBlank
+            lateinit var identificationButtonAriaLabel: String
+
+            @NotBlank
             lateinit var dataPrivacyButton: String
+
+            @NotBlank
+            lateinit var openInNewTab: String
         }
     }
 

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetProperties.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetProperties.kt
@@ -101,6 +101,9 @@ class WidgetProperties {
             lateinit var headlineTitle: String
 
             @NotBlank
+            lateinit var headlineImageAlt: String
+
+            @NotBlank
             lateinit var requirementTitle: String
 
             @NotBlank

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetProperties.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetProperties.kt
@@ -47,6 +47,15 @@ class WidgetProperties {
             lateinit var headlineImageAlt: String
 
             @NotBlank
+            lateinit var appIconImageAlt: String
+
+            @NotBlank
+            lateinit var stepOneAlt: String
+
+            @NotBlank
+            lateinit var stepTwoAlt: String
+
+            @NotBlank
             lateinit var headlineTitleTop: String
 
             @NotBlank

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,10 +82,13 @@ widget:
     localization:
       headline-title-top: Mit BundesIdent
       headline-title-bottom: online ausweisen
-      headline-image-alt: "Drei Ausweisdokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger:innen:innen der Europäischen Union und des Europäischen Wirtschaftsraums."
+      headline-image-alt: "Drei Ausweisdokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger:innen:innen der Europäischen Union und des Europäischen Wirtschaftsraums"
+      app-icon-image-alt: "App Icon: Weißer Bundesadler auf blauem Grund"
+      step-one-alt: Schritt eins
+      step-two-alt: Schritt zwei
       download-title: BundesIdent installieren
-      app-store-alt: Apple App Store Button
-      play-store-alt: Google Play Store Button
+      app-store-alt: Aus dem Apple App Store laden
+      play-store-alt: Aus dem Google Play Store laden
       identification-button: Mit BundesIdent ausweisen
       data-privacy-button: Datenschutzerklärung
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -82,15 +82,15 @@ widget:
     localization:
       headline-title-top: Mit BundesIdent
       headline-title-bottom: online ausweisen
-      headline-image-alt: "Drei Ausweisdokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger:innen:innen der Europäischen Union und des Europäischen Wirtschaftsraums"
-      app-icon-image-alt: "App Icon mit weißem Bundesadler auf blauem Grund"
+      headline-image-alt: "Drei Ausweisdokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger der Europäischen Union und des Europäischen Wirtschaftsraums"
+      app-icon-image-alt: App-Symbol mit weißem Bundesadler auf blauem Grund
       step-one-alt: Schritt eins
       step-two-alt: Schritt zwei
       download-title: BundesIdent installieren
       app-store-alt: Aus dem Apple App Store laden
       play-store-alt: Aus dem Google Play Store laden
       identification-button: Mit BundesIdent ausweisen
-      identification-button-aria-label: Öffnet die BundesIdent App zum ausweisen
+      identification-button-aria-label: Öffnet die BundesIdent App zum Ausweisen
       data-privacy-button: Datenschutzerklärung
       open-in-new-tab: Öffnet in einem neuen Fenster
 
@@ -103,7 +103,7 @@ widget:
     incompatible:
       localization:
         headline-title: Ihr Smartphone erfüllt leider nicht die Voraussetzungen der BundesIdent App.
-        headline-image-alt: Zeichnung eines Smartphones mit traurigem Gesicht und App Icon mit weißem Bundesadler auf blauem Grund
+        headline-image-alt: Zeichnung eines Smartphones mit traurigem Gesicht und App-Symbol mit weißem Bundesadler auf blauem Grund
         requirement-title: "Mindestvoraussetzungen:"
         android-title: Android
         android-requirement: Android 9 »Pie« und ein NFC-Sensor.

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,7 +77,7 @@ csp:
 
 widget:
   meta-tag:
-    header-title: DigitalService GmbH des Bundes
+    header-title: Mit BundesIdent online ausweisen
   main-view:
     localization:
       headline-title-top: Mit BundesIdent

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -90,7 +90,9 @@ widget:
       app-store-alt: Aus dem Apple App Store laden
       play-store-alt: Aus dem Google Play Store laden
       identification-button: Mit BundesIdent ausweisen
+      identification-button-aria-label: Öffnet die BundesIdent App zum ausweisen
       data-privacy-button: Datenschutzerklärung
+      open-in-new-tab: Öffnet in einem neuen Fenster
 
     mobile-url:
       app-store-url: https://apps.apple.com/de/app/bundesident/id1635758944

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -83,7 +83,7 @@ widget:
       headline-title-top: Mit BundesIdent
       headline-title-bottom: online ausweisen
       headline-image-alt: "Drei Ausweisdokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger:innen:innen der Europäischen Union und des Europäischen Wirtschaftsraums"
-      app-icon-image-alt: "App Icon: Weißer Bundesadler auf blauem Grund"
+      app-icon-image-alt: "App Icon mit weißem Bundesadler auf blauem Grund"
       step-one-alt: Schritt eins
       step-two-alt: Schritt zwei
       download-title: BundesIdent installieren
@@ -103,6 +103,7 @@ widget:
     incompatible:
       localization:
         headline-title: Ihr Smartphone erfüllt leider nicht die Voraussetzungen der BundesIdent App.
+        headline-image-alt: Zeichnung eines Smartphones mit traurigem Gesicht und App Icon mit weißem Bundesadler auf blauem Grund
         requirement-title: "Mindestvoraussetzungen:"
         android-title: Android
         android-requirement: Android 9 »Pie« und ein NFC-Sensor.

--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -4,6 +4,7 @@ body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     padding: 0;
+    overflow-x: hidden;
 }
 img.icon-list {
     align-self: start;

--- a/src/main/resources/static/widget.js
+++ b/src/main/resources/static/widget.js
@@ -32,6 +32,7 @@ widgetContainer.appendChild(
       "src",
       `${useIdUrl}/widget?hostname=${location.host}#tcTokenURL=${tcTokenURL}`
     );
+    iframe.name = "Mit BundesIdent online ausweisen";
     iframe.style.width = "100%";
     iframe.style.height = "100%";
     return iframe;

--- a/src/main/resources/templates/incompatible.mustache
+++ b/src/main/resources/templates/incompatible.mustache
@@ -2,7 +2,7 @@
 <div class="container incompatible">
     <div class="widget">
         <div class="incompatible-notification__wrapper">
-            <img src="images/widget-incompatible.svg" alt="image of device" />
+            <img src="images/widget-incompatible.svg" alt="{{localization.headlineImageAlt}}" />
             <h1>{{localization.headlineTitle}}</h1>
             <h3>{{localization.requirementTitle}}</h3>
             <ul role="list">

--- a/src/main/resources/templates/incompatible.mustache
+++ b/src/main/resources/templates/incompatible.mustache
@@ -4,7 +4,7 @@
         <div class="incompatible-notification__wrapper">
             <img src="images/widget-incompatible.svg" alt="{{localization.headlineImageAlt}}" />
             <h1>{{localization.headlineTitle}}</h1>
-            <h3>{{localization.requirementTitle}}</h3>
+            <p>{{localization.requirementTitle}}</p>
             <ul role="list">
                 <li>
                     <p>{{localization.androidTitle}}</p>

--- a/src/main/resources/templates/widget.mustache
+++ b/src/main/resources/templates/widget.mustache
@@ -6,7 +6,7 @@
         {{/localizationError}}
         <div class="cards">
            <img class="img-responsive" src="images/id-1x.png" alt="{{localization.headlineImageAlt}}" srcset="images/id-2x.png 2x" />
-           <img class="app-icon" src="images/app-icon.svg" />
+           <img class="app-icon" src="images/app-icon.svg" alt="{{localization.appIconImageAlt}}" />
         </div>
         <div class="headline">
             <h1>{{localization.headlineTitleTop}} <br> {{localization.headlineTitleBottom}}</h1>
@@ -14,7 +14,7 @@
         <div class="app-stores">
             <div class="connector-inside"></div>
             <div class="app-stores__wrapper">
-                <img class="icon-list" src="images/list-1.svg" />
+                <img class="icon-list" src="images/list-1.svg" alt="{{localization.stepOneAlt}}"/>
                 <div class="app-stores__content">
                     <h2>{{localization.downloadTitle}}</h2>
                     <div class="app-stores__content__images">
@@ -30,7 +30,7 @@
         </div>
         <div class="connector-outside"></div>
         <a id="eid-client-button" href={{eidClientURL}} target="_blank" class="identify">
-            <img class="icon-list" src="images/list-2.svg" alt />
+            <img class="icon-list" src="images/list-2.svg" alt="{{localization.stepTwoAlt}}"/>
             <h2>{{localization.identificationButton}}</h2>
         </a>
         <div class="data-privacy-wrapper">

--- a/src/main/resources/templates/widget.mustache
+++ b/src/main/resources/templates/widget.mustache
@@ -18,10 +18,10 @@
                 <div class="app-stores__content">
                     <h2>{{localization.downloadTitle}}</h2>
                     <div class="app-stores__content__images">
-                        <a href={{mobileUrl.playStoreUrl}} target="_blank">
+                        <a href={{mobileUrl.playStoreUrl}} target="_blank" aria-label="{{localization.openInNewTab}}">
                             <img class="play-store" loading="lazy" src="images/play-store.svg" alt="{{localization.playStoreAlt}}" />
                         </a>
-                        <a href={{mobileUrl.appStoreUrl}} target="_blank">
+                        <a href={{mobileUrl.appStoreUrl}} target="_blank" aria-label="{{localization.openInNewTab}}">
                             <img class="app-store" loading="lazy" src="images/app-store.svg" alt="{{localization.appStoreAlt}}" />
                         </a>
                     </div>
@@ -29,12 +29,12 @@
             </div>
         </div>
         <div class="connector-outside"></div>
-        <a id="eid-client-button" href={{eidClientURL}} target="_blank" class="identify">
+        <a id="eid-client-button" href={{eidClientURL}} target="_blank" class="identify" aria-label="{{localization.identificationButtonAriaLabel}}">
             <img class="icon-list" src="images/list-2.svg" alt="{{localization.stepTwoAlt}}"/>
             <h2>{{localization.identificationButton}}</h2>
         </a>
         <div class="data-privacy-wrapper">
-            <a id="eid-client-button" href={{mobileUrl.dataPrivacy}} target="_blank" class="data-privacy-button">
+            <a id="eid-client-button" href={{mobileUrl.dataPrivacy}} target="_blank" class="data-privacy-button" aria-label="{{localization.openInNewTab}}">
                 {{localization.dataPrivacyButton}} ↗
             </a>
         </div>

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -54,27 +54,33 @@ tracking:
 
 widget:
   meta-tag:
-    header-title: DigitalService GmbH des Bundes
+    header-title: Mit BundesIdent online ausweisen
   main-view:
     localization:
       headline-title-top: Mit BundesIdent
       headline-title-bottom: online ausweisen
-      headline-image-alt: "Drei deutsche Dokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger:innen:innen der Europäischen Union und des Europäischen Wirtschaftsraums."
-      download-title: BundesIdent herunterladen
-      app-store-alt: Google Play Store Button
-      play-store-alt: Apple App Store Button
+      headline-image-alt: "Drei Ausweisdokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger:innen:innen der Europäischen Union und des Europäischen Wirtschaftsraums"
+      app-icon-image-alt: "App Icon mit weißem Bundesadler auf blauem Grund"
+      step-one-alt: Schritt eins
+      step-two-alt: Schritt zwei
+      download-title: BundesIdent installieren
+      app-store-alt: Aus dem Apple App Store laden
+      play-store-alt: Aus dem Google Play Store laden
       identification-button: Mit BundesIdent ausweisen
+      identification-button-aria-label: Öffnet die BundesIdent App zum ausweisen
       data-privacy-button: Datenschutzerklärung
+      open-in-new-tab: Öffnet in einem neuen Fenster
 
     mobile-url:
       app-store-url: https://apps.apple.com/de/app/bundesident/id1635758944
       play-store-url: https://play.google.com/store/apps/details?id=de.digitalService.useID
-      data-privacy: foobar
+      data-privacy: https://digitalservice.bund.de/datenschutzerklaerung-bundesident
 
   error-view:
     incompatible:
       localization:
-        headline-title: Ihr Smartphone ist nicht mit der BundesIdent App kompatibel.
+        headline-title: Ihr Smartphone erfüllt leider nicht die Voraussetzungen der BundesIdent App.
+        headline-image-alt: Zeichnung eines Smartphones mit traurigem Gesicht und App Icon mit weißem Bundesadler auf blauem Grund
         requirement-title: "Mindestvoraussetzungen:"
         android-title: Android
         android-requirement: Android 9 »Pie« und ein NFC-Sensor.

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -60,14 +60,14 @@ widget:
       headline-title-top: Mit BundesIdent
       headline-title-bottom: online ausweisen
       headline-image-alt: "Drei Ausweisdokumente: Personalausweis, elektronischer Aufenthaltstitel und die eID-Karte für Bürgerinnen und Bürger:innen:innen der Europäischen Union und des Europäischen Wirtschaftsraums"
-      app-icon-image-alt: "App Icon mit weißem Bundesadler auf blauem Grund"
+      app-icon-image-alt: App-Symbol mit weißem Bundesadler auf blauem Grund
       step-one-alt: Schritt eins
       step-two-alt: Schritt zwei
       download-title: BundesIdent installieren
       app-store-alt: Aus dem Apple App Store laden
       play-store-alt: Aus dem Google Play Store laden
       identification-button: Mit BundesIdent ausweisen
-      identification-button-aria-label: Öffnet die BundesIdent App zum ausweisen
+      identification-button-aria-label: Öffnet die BundesIdent App zum Ausweisen
       data-privacy-button: Datenschutzerklärung
       open-in-new-tab: Öffnet in einem neuen Fenster
 
@@ -80,7 +80,7 @@ widget:
     incompatible:
       localization:
         headline-title: Ihr Smartphone erfüllt leider nicht die Voraussetzungen der BundesIdent App.
-        headline-image-alt: Zeichnung eines Smartphones mit traurigem Gesicht und App Icon mit weißem Bundesadler auf blauem Grund
+        headline-image-alt: Zeichnung eines Smartphones mit traurigem Gesicht und App-Symbol mit weißem Bundesadler auf blauem Grund
         requirement-title: "Mindestvoraussetzungen:"
         android-title: Android
         android-requirement: Android 9 »Pie« und ein NFC-Sensor.


### PR DESCRIPTION
As a disabled user I want to be able to use the web widget to be able to use the online identification.

* Fulfil all points on the [Accessibility Guideline](https://accessibility.18f.gov/checklist/)
* Fulfil level 1 requirements on the [IBM accessibility requirements list](https://www.ibm.com/able/requirements/requirements/) 