### PR TITLE
USEID-572: Incompatible Page — Part 2

### DIFF
--- a/src/main/kotlin/de/bund/digitalservice/useid/config/ContentSecurityPolicyFilter.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/config/ContentSecurityPolicyFilter.kt
@@ -1,6 +1,5 @@
 package de.bund.digitalservice.useid.config
 
-import de.bund.digitalservice.useid.widget.INCOMPATIBLE_PAGE
 import de.bund.digitalservice.useid.widget.WIDGET_PAGE
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.http.server.reactive.ServerHttpResponse
@@ -16,8 +15,7 @@ class ContentSecurityPolicyFilter(
 ) : WebFilter {
 
     private val widgetPagePath: PathPattern = PathPatternParser().parse("/$WIDGET_PAGE")
-    private val incompatiblePagePath: PathPattern = PathPatternParser().parse("/$INCOMPATIBLE_PAGE")
-    private val listOfPages = listOf(widgetPagePath, incompatiblePagePath)
+    private val listOfPages = listOf(widgetPagePath)
 
     override fun filter(
         serverWebExchange: ServerWebExchange,

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -68,7 +68,7 @@ class WidgetController(
         )
 
         if (isIncompatibleOSVersion(userAgent)) {
-            return handleRequestWithIncompatibleOSVersion()
+            return handleRequestWithIncompatibleOSVersion(sessionHash)
         }
 
         return Rendering
@@ -142,11 +142,12 @@ class WidgetController(
             Integer.parseInt(parsedUserAgent.os.major) < supportedMajorVersion
     }
 
-    private fun handleRequestWithIncompatibleOSVersion(): Rendering {
+    private fun handleRequestWithIncompatibleOSVersion(sessionHash: String?): Rendering {
         publishMatomoEvent(
             widgetTracking.categories.widget,
             widgetTracking.actions.loaded,
-            widgetTracking.names.incompatible
+            widgetTracking.names.incompatible,
+            sessionHash
         )
 
         val incompatibleViewConfig = mapOf(

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -12,6 +12,7 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.reactive.result.view.Rendering
 import ua_parser.Client
 import ua_parser.Parser
@@ -47,6 +48,7 @@ class WidgetController(
     @GetMapping("/$WIDGET_PAGE")
     fun getWidgetPage(
         @RequestHeader("User-Agent") userAgent: String,
+        @RequestParam() hostname: String,
         model: Model
     ): Rendering {
         publishMatomoEvent(

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -76,25 +76,6 @@ class WidgetController(
             .build()
     }
 
-    @GetMapping("/$INCOMPATIBLE_PAGE")
-    fun getIncompatiblePage(model: Model): Rendering {
-        publishMatomoEvent(
-            widgetTracking.categories.widget,
-            widgetTracking.actions.loaded,
-            widgetTracking.names.incompatible
-        )
-
-        val incompatibleViewConfig = mapOf(
-            "localization" to widgetProperties.errorView.incompatible.localization
-        )
-
-        return Rendering
-            .view(INCOMPATIBLE_PAGE)
-            .model(defaultViewHeaderConfig + incompatibleViewConfig)
-            .status(HttpStatus.OK)
-            .build()
-    }
-
     @GetMapping("/$FALLBACK_PAGE")
     fun getUniversalLinkFallbackPage(model: Model, serverHttpRequest: ServerHttpRequest): Rendering {
         publishMatomoEvent(

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -106,28 +106,17 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
     }
 
     @Test
-    fun `widget endpoint redirects to INCOMPATIBLE_PAGE when the devices are unsupported`() {
+    fun `widget endpoint renders INCOMPATIBLE_PAGE when the devices are unsupported`() {
         val incompatibleAndroidUserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; SM-G960F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36"
         val incompatibleIOSUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
 
         val (iosResponse, androidResponse) = fetchWidgetPageWithMobileDevices(incompatibleAndroidUserAgent, incompatibleIOSUserAgent)
 
-        iosResponse.expectStatus().is3xxRedirection
-        androidResponse.expectStatus().is3xxRedirection
-    }
+        val iOSResponseBody = iosResponse.expectBody().returnResult().responseBody?.decodeToString()
+        val androidResponseBody = androidResponse.expectBody().returnResult().responseBody?.decodeToString()
 
-    @Test
-    fun `widget endpoint INCOMPATIBLE_PAGE should return 200 and should contain headlineTitle`() {
-        val result = webTestClient
-            .get()
-            .uri("/$INCOMPATIBLE_PAGE")
-            .exchange()
-            .expectStatus().isOk
-            .expectBody()
-            .returnResult()
-
-        val body = String(result.responseBody!!)
-        assertThat(body, containsString(widgetProperties.errorView.incompatible.localization.headlineTitle))
+        assertThat(iOSResponseBody, containsString(widgetProperties.errorView.incompatible.localization.headlineTitle))
+        assertThat(androidResponseBody, containsString(widgetProperties.errorView.incompatible.localization.headlineTitle))
     }
 
     @Test
@@ -140,7 +129,7 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
             .expectBody()
             .returnResult()
 
-        val body = String(result.responseBody!!)
+        val body = result.responseBody?.decodeToString()
         assertThat(body, containsString(widgetProperties.errorView.fallback.localization.errorTitle))
         assertThat(body, containsString("class=\"container fallback\""))
     }


### PR DESCRIPTION
# Problem
This improvement was raised by @phuesler and we agree that the current implementation leads to unnecessary redirect and another endpoint is another maintenance. Keep it simple.

# Proposed changes
### Old implementation:
- Any request with incompatible OS version should be redirected to `/incompatible` path

### New implementation
- Any request with incompatible OS version, the widget itself will render the `incompatible` page template.
- Path will stay same (`/widget`)
- Content Security Policy will follow as the one from widget, we don't need to set it in the `WebFilter` anymore

