### PR TITLE
USEID-671: Add vendor prefix for last 2 version

### DIFF
--- a/src/main/resources/static/css/sanitize.css
+++ b/src/main/resources/static/css/sanitize.css
@@ -11,6 +11,7 @@
 *,
 ::before,
 ::after {
+  -webkit-box-sizing: border-box;
   box-sizing: border-box; /* 1 */
   background-repeat: no-repeat; /* 2 */
 }
@@ -40,6 +41,7 @@
   line-height: 1.5; /* 2 */
   overflow-wrap: break-word; /* 3 */
   -moz-tab-size: 4; /* 4 */
+  -o-tab-size: 4;
   tab-size: 4; /* 4 */
   -webkit-tap-highlight-color: transparent; /* 5 */
   -webkit-text-size-adjust: 100%; /* 6 */
@@ -126,7 +128,7 @@
 
 :where(abbr[title]) {
   text-decoration: underline;
-  text-decoration: underline dotted;
+  -webkit-text-decoration: underline dotted;
 }
 
 /**
@@ -300,6 +302,7 @@
   border: solid;
   color: black;
   height: -moz-fit-content;
+  height: -webkit-fit-content;
   height: fit-content;
   left: 0;
   margin: auto;
@@ -307,6 +310,7 @@
   position: absolute;
   right: 0;
   width: -moz-fit-content;
+  width: -webkit-fit-content;
   width: fit-content;
 }
 

--- a/src/main/resources/static/css/widget.css
+++ b/src/main/resources/static/css/widget.css
@@ -7,6 +7,7 @@ body {
     overflow-x: hidden;
 }
 img.icon-list {
+    -ms-flex-item-align: start;
     align-self: start;
     z-index: 1;
 }
@@ -41,17 +42,30 @@ h2 {
     margin-bottom: 0.5rem;
 }
 .app-stores__wrapper {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
     grid-column-gap: 9px;
     grid-row-gap: 9px;
 }
 .app-stores__content {
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
+    -webkit-box-pack: start;
+    -ms-flex-pack: start;
     justify-content: start;
 }
 .app-stores__content__images {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
     flex-direction: row;
+    -ms-flex-wrap: wrap;
     flex-wrap: wrap;
     grid-column-gap: 12px;
     grid-row-gap: 10px;
@@ -65,14 +79,22 @@ h2 {
 }
 .app-stores__content__images a:focus-visible {
     border-radius: 10px;
-    -moz-box-shadow:    0 0 0 4px #fff, 0 0 0 8px #004b76;
     -webkit-box-shadow: 0 0 0 4px #fff, 0 0 0 8px #004b76;
-    box-shadow:         0 0 0 4px #fff, 0 0 0 8px #004b76;
+    box-shadow: 0 0 0 4px #fff, 0 0 0 8px #004b76;
 }
 .cards {
+    -webkit-box-align: center;
+    -ms-flex-align: center;
     align-items: center;
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
     justify-content: center;
 }
 .connector-inside {
@@ -98,19 +120,35 @@ h2 {
     padding: 4vw;
 }
 .headline {
+    -webkit-box-align: center;
+    -ms-flex-align: center;
     align-items: center;
     color: #0B0C0C;
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
     justify-content: center;
     margin: 10px 0 16px 0;
 }
 .identify {
+    -webkit-box-align: center;
+    -ms-flex-align: center;
     align-items: center;
     background-color: #004B76;
     border-radius: 10px;
     color: white;
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: row;
     flex-direction: row;
     grid-column-gap: 9px;
     grid-row-gap: 9px;
@@ -127,17 +165,23 @@ h2 {
     color: #0B0C0C;
 }
 .identify:focus-visible {
-    -moz-box-shadow:    0 0 0 4px #fff, 0 0 0 8px #004b76;
     -webkit-box-shadow: 0 0 0 4px #fff, 0 0 0 8px #004b76;
-    box-shadow:         0 0 0 4px #fff, 0 0 0 8px #004b76;
+    box-shadow: 0 0 0 4px #fff, 0 0 0 8px #004b76;
 }
 .identify h2 {
     margin: 0;
 }
 .data-privacy-wrapper {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
     margin-top: 8px;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
+    -webkit-box-align: end;
+    -ms-flex-align: end;
     align-items: flex-end;
 }
 .data-privacy-button {
@@ -174,11 +218,17 @@ h2 {
     background-color: #f2f6f8;
     color: #333;
     border-radius: 10px;
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
     padding: 16px;
 }
 .incompatible-notification__wrapper img {
+    -ms-flex-item-align: center;
     align-self: center;
     max-width: 180px;
     margin-top: -80px;
@@ -198,7 +248,12 @@ h2 {
 }
 .incompatible-notification__wrapper ul {
     color: #666;
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    -ms-flex-direction: column;
     flex-direction: column;
     grid-column-gap: 4px;
     grid-row-gap: 4px;

--- a/src/main/resources/static/css/widgetError.css
+++ b/src/main/resources/static/css/widgetError.css
@@ -6,9 +6,13 @@
 }
 
 .error_wrapper {
+    display: -webkit-box;
+    display: -ms-flexbox;
     display: flex;
     margin-bottom: 28px;
     padding: 16px 14px 13px 16px;
+    -webkit-box-align: start;
+    -ms-flex-align: start;
     align-items: flex-start;
     grid-column-gap: 8px;
     grid-row-gap: 8px;


### PR DESCRIPTION
# Problem
Current CSS is not supporting all browsers

# Proposed changes
- Add vendor prefixes for ALL last 2 browser version (https://browserslist.dev/?q=bGFzdCAyIHZlcnNpb25z). The changes are generated by PostCSS Autoprefixer (https://github.com/postcss/autoprefixer) with manual fixes on the indentation 
