### PR TITLE
NO-TICKET: encode tcTokenURL in fallback page

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
     testImplementation("org.testcontainers:r2dbc:1.17.3")
     testImplementation("org.testcontainers:mysql:1.17.3")
     testImplementation("org.awaitility:awaitility:4.2.0")
+    testImplementation("org.jsoup:jsoup:1.15.3")
 
     /** Spring Cloud **/
     implementation("org.springframework.cloud:spring-cloud-starter-kubernetes-client-config:2.1.3")

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.reactive.result.view.Rendering
 import ua_parser.Client
 import ua_parser.Parser
 import java.net.URLEncoder
+import kotlin.text.Charsets.UTF_8
 
 internal const val WIDGET_PAGE = "widget"
 internal const val INCOMPATIBLE_PAGE = "incompatible"
@@ -92,7 +93,7 @@ class WidgetController(
             Specifications Version 1.4 8. October 2021, Chapter 2.2 Full eID-Client
             Note: Replaced the prefix eid:// with bundesident:// to make sure only the BundesIdent app is opened
          */
-        val url = "bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=${URLEncoder.encode(tcTokenURL, Charsets.UTF_8)}"
+        val url = "bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=${URLEncoder.encode(tcTokenURL, UTF_8)}"
 
         val widgetViewFallbackConfig = mapOf(
             setMainViewLocalization(),

--- a/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/widget/WidgetController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.reactive.result.view.Rendering
 import ua_parser.Client
 import ua_parser.Parser
+import java.net.URLEncoder
 
 internal const val WIDGET_PAGE = "widget"
 internal const val INCOMPATIBLE_PAGE = "incompatible"
@@ -91,7 +92,7 @@ class WidgetController(
             Specifications Version 1.4 8. October 2021, Chapter 2.2 Full eID-Client
             Note: Replaced the prefix eid:// with bundesident:// to make sure only the BundesIdent app is opened
          */
-        val url = "bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=$tcTokenURL"
+        val url = "bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=${URLEncoder.encode(tcTokenURL, Charsets.UTF_8)}"
 
         val widgetViewFallbackConfig = mapOf(
             setMainViewLocalization(),

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -165,26 +165,6 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
     }
 
     @Test
-    fun `fallback page should encode tcTokenURL param for identification button when the query param is not encoded`() {
-        val decodedTcTokenUrl = "https://www.foo.bar"
-        val result = webTestClient
-            .get()
-            .uri("/$FALLBACK_PAGE?tcTokenURL=$decodedTcTokenUrl")
-            .exchange()
-            .expectStatus().isOk
-            .expectBody()
-            .returnResult()
-
-        val responseBody: String? = result.responseBody?.decodeToString()
-        val parsedResponseBody = Jsoup.parse(responseBody!!)
-
-        val eidClientButton = parsedResponseBody.getElementById("eid-client-button")?.attr("href")
-        val hasCorrectUrl = containsString("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%3A%2F%2Fwww.foo.bar")
-
-        assertThat(eidClientButton, hasCorrectUrl)
-    }
-
-    @Test
     fun `widget endpoint APP_OPENED should return 200`() {
         webTestClient
             .post()

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -159,7 +159,7 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
         val parsedResponseBody = Jsoup.parse(responseBody!!)
 
         val eidClientButton = parsedResponseBody.getElementById("eid-client-button")?.attr("href")
-        val hasCorrectUrl = containsString("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%253A%252F%252Fwww.foo.bar")
+        val hasCorrectUrl = containsString("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%3A%2F%2Fwww.foo.bar")
 
         assertThat(eidClientButton, hasCorrectUrl)
     }
@@ -179,7 +179,7 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
         val parsedResponseBody = Jsoup.parse(responseBody!!)
 
         val eidClientButton = parsedResponseBody.getElementById("eid-client-button")?.attr("href")
-        val hasCorrectUrl = containsString("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%253A%252F%252Fwww.foo.bar")
+        val hasCorrectUrl = containsString("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%3A%2F%2Fwww.foo.bar")
 
         assertThat(eidClientButton, hasCorrectUrl)
     }

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -146,10 +146,10 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
 
     @Test
     fun `fallback page should encode tcTokenURL param for identification button when the query param is passed`() {
-        val encodedTcTokenUrl = "https%3A%2F%2Fwww.foo.bar"
+        val tcTokenUrl = "https://www.foo.bar"
         val result = webTestClient
             .get()
-            .uri("/$FALLBACK_PAGE?tcTokenURL=$encodedTcTokenUrl")
+            .uri("/$FALLBACK_PAGE?tcTokenURL=$tcTokenUrl") // tcTokenURL is automatically encoded by webTestClient
             .exchange()
             .expectStatus().isOk
             .expectBody()

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -3,6 +3,7 @@ package de.bund.digitalservice.useid.widget
 import de.bund.digitalservice.useid.util.PostgresTestcontainerIntegrationTest
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert.assertThat
+import org.jsoup.Jsoup
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -129,9 +130,58 @@ class WidgetControllerIntegrationTest(@Autowired val webTestClient: WebTestClien
             .expectBody()
             .returnResult()
 
-        val body = result.responseBody?.decodeToString()
-        assertThat(body, containsString(widgetProperties.errorView.fallback.localization.errorTitle))
-        assertThat(body, containsString("class=\"container fallback\""))
+        val responseBody: String? = result.responseBody?.decodeToString()
+        val parsedResponseBody = Jsoup.parse(responseBody!!)
+
+        val containerFallback = parsedResponseBody.body().firstElementChild()?.className()
+        val hasValidFallbackClassName = containsString("container fallback")
+
+        assertThat(containerFallback, hasValidFallbackClassName)
+
+        val errorTitle = parsedResponseBody.getElementsByClass("error_title").text()
+        val hasValidErrorTitle = containsString(widgetProperties.errorView.fallback.localization.errorTitle)
+
+        assertThat(errorTitle, hasValidErrorTitle)
+    }
+
+    @Test
+    fun `fallback page should encode tcTokenURL param for identification button when the query param is passed`() {
+        val encodedTcTokenUrl = "https%3A%2F%2Fwww.foo.bar"
+        val result = webTestClient
+            .get()
+            .uri("/$FALLBACK_PAGE?tcTokenURL=$encodedTcTokenUrl")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .returnResult()
+
+        val responseBody: String? = result.responseBody?.decodeToString()
+        val parsedResponseBody = Jsoup.parse(responseBody!!)
+
+        val eidClientButton = parsedResponseBody.getElementById("eid-client-button")?.attr("href")
+        val hasCorrectUrl = containsString("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%253A%252F%252Fwww.foo.bar")
+
+        assertThat(eidClientButton, hasCorrectUrl)
+    }
+
+    @Test
+    fun `fallback page should encode tcTokenURL param for identification button when the query param is not encoded`() {
+        val decodedTcTokenUrl = "https://www.foo.bar"
+        val result = webTestClient
+            .get()
+            .uri("/$FALLBACK_PAGE?tcTokenURL=$decodedTcTokenUrl")
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .returnResult()
+
+        val responseBody: String? = result.responseBody?.decodeToString()
+        val parsedResponseBody = Jsoup.parse(responseBody!!)
+
+        val eidClientButton = parsedResponseBody.getElementById("eid-client-button")?.attr("href")
+        val hasCorrectUrl = containsString("bundesident://127.0.0.1:24727/eID-Client?tcTokenURL=https%253A%252F%252Fwww.foo.bar")
+
+        assertThat(eidClientButton, hasCorrectUrl)
     }
 
     @Test


### PR DESCRIPTION
# Problem
Fallback page button does not encode `tcTokenUrl` query param, when it's passed from `/widget` page

# Proposed changes
- Add 2 test cases for encoded and not-encoded tcTokenUrl
- Add `jsoup` package for testing. Since Hamcrest does not have HTML matcher, `jsoup` parses the html string returned by the `WebTestClient` and give us more easy to understand API, such as `getElementById(String id)` for finding element with an id

### Old test
```kotlin
val body = result.responseBody?.decodeToString()
assertThat(body, containsString("class=\"container fallback\""))
```

we can have more declarative way of testing, (it could increase developer experience)

### New test
```kotlin
val responseBody: String? = result.responseBody?.decodeToString()
val parsedResponseBody = Jsoup.parse(responseBody!!)

val containerFallback = parsedResponseBody.body().firstElementChild()?.className()
val hasValidFallbackClassName = containsString("container fallback")

assertThat(containerFallback, hasValidFallbackClassName)
```