### PR TITLE
NO-TICKET: Add CORS header

### DIFF
--- a/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityConfig.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityConfig.kt
@@ -32,7 +32,7 @@ class SecurityConfig(
                 SecurityWebFiltersOrder.REACTOR_CONTEXT
             )
             .addFilterAfter(
-                ContentSecurityPolicyFilter(contentSecurityPolicyProperties),
+                SecurityHeadersFilter(contentSecurityPolicyProperties),
                 SecurityWebFiltersOrder.LAST
             )
             .build()

--- a/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityHeadersFilter.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityHeadersFilter.kt
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.useid.config
 
 import de.bund.digitalservice.useid.widget.WIDGET_PAGE
+import org.springframework.http.HttpHeaders
 import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.web.server.ServerWebExchange
@@ -10,7 +11,7 @@ import org.springframework.web.util.pattern.PathPattern
 import org.springframework.web.util.pattern.PathPatternParser
 import reactor.core.publisher.Mono
 
-class ContentSecurityPolicyFilter(
+class SecurityHeadersFilter(
     private val contentSecurityPolicyProperties: ContentSecurityPolicyProperties
 ) : WebFilter {
 
@@ -31,10 +32,12 @@ class ContentSecurityPolicyFilter(
         val hostNameIsAllowed = hostName?.let { contentSecurityPolicyProperties.domainIsAllowed(it) }
 
         if (hostNameIsAllowed == true) {
-            response.headers.set(
-                "Content-Security-Policy",
-                contentSecurityPolicyProperties.getCSPHeaderValue(hostName)
+            val securityHeaders = mapOf(
+                "Content-Security-Policy" to contentSecurityPolicyProperties.getCSPHeaderValue(hostName),
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN to hostName
             )
+
+            response.headers.setAll(securityHeaders)
         } else {
             response.headers.set(
                 "Content-Security-Policy",

--- a/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityHeadersFilter.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityHeadersFilter.kt
@@ -34,7 +34,8 @@ class SecurityHeadersFilter(
         if (hostNameIsAllowed == true) {
             val securityHeaders = mapOf(
                 "Content-Security-Policy" to contentSecurityPolicyProperties.getCSPHeaderValue(hostName),
-                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN to hostName
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN to hostName,
+                HttpHeaders.VARY to HttpHeaders.ORIGIN
             )
 
             response.headers.setAll(securityHeaders)

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.MessageSource
+import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import java.util.Locale
@@ -43,6 +44,11 @@ class WidgetControllerIntegrationTest(
                 "Content-Security-Policy",
                 "some default value;frame-ancestors 'self' foo.bar;"
             )
+            .expectHeader()
+            .valueEquals(
+                HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+                "foo.bar"
+            )
     }
 
     @Test
@@ -58,6 +64,8 @@ class WidgetControllerIntegrationTest(
                 "Content-Security-Policy",
                 "some default value;frame-ancestors 'self';"
             )
+            .expectHeader()
+            .doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)
     }
 
     @Test
@@ -73,6 +81,8 @@ class WidgetControllerIntegrationTest(
                 "Content-Security-Policy",
                 "some default value;frame-ancestors 'self';"
             )
+            .expectHeader()
+            .doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)
     }
 
     @Test

--- a/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/widget/WidgetControllerIntegrationTest.kt
@@ -49,6 +49,8 @@ class WidgetControllerIntegrationTest(
                 HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
                 "foo.bar"
             )
+            .expectHeader()
+            .valueEquals(HttpHeaders.VARY, HttpHeaders.ORIGIN)
     }
 
     @Test


### PR DESCRIPTION
Widget responds the Access-Control-Allow-Origin header