### PR TITLE
NO-TICKET: Update app properties for sentry

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -48,6 +48,9 @@ csp:
 features:
   desktop-solution-enabled: true
 
-sentry:
-  environment: staging
-  traces-sample-rate: 1.0
+# Uncomment this section if you would like to validate that
+#the exception will get sent to Sentry.
+#
+#sentry:
+#  environment: staging
+#  traces-sample-rate: 1.0

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -47,3 +47,7 @@ csp:
 
 features:
   desktop-solution-enabled: true
+
+sentry:
+  environment: staging
+  traces-sample-rate: 1.0


### PR DESCRIPTION
**As** a developer,
**I want** to check whether the error will be sent to Sentry or not
**so that** I can differentiate the production error and staging error
**and** I don't pollute production error events

-- 

if we don't set the environment explicitly, Sentry assumes the production environment.