### PR TITLE
NO-TICKET: Fix api documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,11 +280,11 @@ the name `SLACK_WEBHOOK_URL`, containing a url for [Incoming Webhooks](https://a
 ## API documentation
 
 - Production:
-  - [Swagger UI](https://eid.digitalservicebund.de/api/docs/ui)
-  - [JSON](https://eid.digitalservicebund.de/api/docs/ui)
+  - [Swagger UI](https://eid.digitalservicebund.de/api/docs)
+  - [JSON](https://eid.digitalservicebund.de/api/docs.json)
 - Staging:
-  - [Swagger UI](https://useid.dev.ds4g.net/api/docs/ui)
-  - [JSON](https://useid.dev.ds4g.net/api/docs)
+  - [Swagger UI](https://useid.dev.ds4g.net/api/docs)
+  - [JSON](https://useid.dev.ds4g.net/api/docs.json)
 - Local
-  - [Swagger UI](http://localhost:8080/api/docs/ui)
-  - [JSON](http://localhost:8080/api/docs)
+  - [Swagger UI](http://localhost:8080/api/docs)
+  - [JSON](http://localhost:8080/api/docs.json)

--- a/README.md
+++ b/README.md
@@ -277,10 +277,14 @@ See https://github.com/npryce/adr-tools regarding usage.
 Opt in to CI posting notifications for failing jobs to a particular Slack channel by setting a repository secret with
 the name `SLACK_WEBHOOK_URL`, containing a url for [Incoming Webhooks](https://api.slack.com/messaging/webhooks).
 
-## Swagger/OpenAPI
+## API documentation
 
-How to access the page:
-
-1. [Production](https://eid.digitalservicebund.de/swagger/docs.html)
-2. [Staging](https://useid.dev.ds4g.net/swagger/docs.html)
-3. [Local](http://localhost:8080/swagger/docs.html)
+- Production:
+  - [Swagger UI](https://eid.digitalservicebund.de/api/docs/ui)
+  - [JSON](https://eid.digitalservicebund.de/api/docs/ui)
+- Staging:
+  - [Swagger UI](https://useid.dev.ds4g.net/api/docs/ui)
+  - [JSON](https://useid.dev.ds4g.net/api/docs)
+- Local
+  - [Swagger UI](http://localhost:8080/api/docs/ui)
+  - [JSON](http://localhost:8080/api/docs)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,8 +57,6 @@ dependencies {
 
     /** Data processing **/
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    // => CVE-2022-42003, CVE-2022-42004
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1")
 
     /** Kotlin specific **/
     implementation("org.jetbrains.kotlin:kotlin-reflect")
@@ -66,8 +64,8 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.0")
 
     /** Docs **/
-    implementation("org.springdoc:springdoc-openapi-ui:1.6.9")
-    runtimeOnly("org.springdoc:springdoc-openapi-kotlin:1.6.9")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4")
 
     /** Governikus Autent SDK **/
     implementation("de.governikus.autent.sdk:eid-webservice-sdk:3.73.9")

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -42,3 +42,6 @@ csp:
 
 features:
   desktop-solution-enabled: true
+
+springdoc:
+  show-actuator: true

--- a/src/main/resources/application-staging.yaml
+++ b/src/main/resources/application-staging.yaml
@@ -13,3 +13,6 @@ sentry:
 
 features:
   desktop-solution-enabled: true
+
+springdoc:
+  show-actuator: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,9 +36,9 @@ spring:
 
 springdoc:
   api-docs:
-    path: /v1
+    path: /api/docs
   swagger-ui:
-    path: /swagger/docs.html
+    path: /api/docs/ui
     operationsSorter: method
 
 eidservice:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,9 +36,9 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api/docs
+    path: /api/docs.json
   swagger-ui:
-    path: /api/docs/ui
+    path: /api/docs
     operationsSorter: method
 
 eidservice:

--- a/src/test/kotlin/de/bund/digitalservice/useid/api/ApiDocsIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/api/ApiDocsIntegrationTest.kt
@@ -1,0 +1,43 @@
+package de.bund.digitalservice.useid.api
+
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Tag("integration")
+class ApiDocsIntegrationTest(@Autowired val webTestClient: WebTestClient) {
+
+    @Test
+    fun `api docs ui endpoint returns redirects to swagger ui`() {
+        webTestClient
+            .get()
+            .uri("/api/docs/ui")
+            .exchange()
+            .expectStatus().is3xxRedirection
+            .expectHeader().location("/api/docs/swagger-ui/index.html")
+    }
+
+    @Test
+    fun `swagger ui endpoint returns html page successfully`() {
+        webTestClient
+            .get()
+            .uri("/api/docs/swagger-ui/index.html")
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().contentType(MediaType.TEXT_HTML)
+    }
+
+    @Test
+    fun `api docs endpoint returns json representation of api docs successfully`() {
+        webTestClient
+            .get()
+            .uri("/api/docs")
+            .exchange()
+            .expectStatus().isOk
+            .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    }
+}

--- a/src/test/kotlin/de/bund/digitalservice/useid/api/ApiDocsIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/api/ApiDocsIntegrationTest.kt
@@ -15,17 +15,17 @@ class ApiDocsIntegrationTest(@Autowired val webTestClient: WebTestClient) {
     fun `api docs ui endpoint returns redirects to swagger ui`() {
         webTestClient
             .get()
-            .uri("/api/docs/ui")
+            .uri("/api/docs")
             .exchange()
             .expectStatus().is3xxRedirection
-            .expectHeader().location("/api/docs/swagger-ui/index.html")
+            .expectHeader().location("/api/swagger-ui/index.html")
     }
 
     @Test
     fun `swagger ui endpoint returns html page successfully`() {
         webTestClient
             .get()
-            .uri("/api/docs/swagger-ui/index.html")
+            .uri("/api/swagger-ui/index.html")
             .exchange()
             .expectStatus().isOk
             .expectHeader().contentType(MediaType.TEXT_HTML)
@@ -35,7 +35,7 @@ class ApiDocsIntegrationTest(@Autowired val webTestClient: WebTestClient) {
     fun `api docs endpoint returns json representation of api docs successfully`() {
         webTestClient
             .get()
-            .uri("/api/docs")
+            .uri("/api/docs.json")
             .exchange()
             .expectStatus().isOk
             .expectHeader().contentType(MediaType.APPLICATION_JSON)

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -65,3 +65,9 @@ spring:
     password: secret
   profiles:
     active: test
+
+springdoc:
+  api-docs:
+    path: /api/docs
+  swagger-ui:
+    path: /api/docs/ui

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -68,6 +68,6 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api/docs
+    path: /api/docs.json
   swagger-ui:
-    path: /api/docs/ui
+    path: /api/docs


### PR DESCRIPTION
- Update springdoc dependencies to be compatible with Spring Boot 3
- Cleanup endpoints 
- Add tests to validate if api docs are available
- Include actuator endpoints to api docs for local and staging environment
- Update README