### PR TITLE
NO-TICKET: Dependencies update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,8 +64,8 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.0")
 
     /** Docs **/
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.0.4")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.1.0")
 
     /** Governikus Autent SDK **/
     implementation("de.governikus.autent.sdk:eid-webservice-sdk:3.73.9")


### PR DESCRIPTION
Because of https://github.com/digitalservicebund/useid-backend-service/pull/236, they need to be updated together (after building the backend locally)

