### PR TITLE
Useid 919 migrate identification endpoints

### DIFF
--- a/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityConfig.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package de.bund.digitalservice.useid.config
 
 import de.bund.digitalservice.useid.identification.IDENTIFICATION_SESSIONS_BASE_PATH
+import de.bund.digitalservice.useid.identification.IDENTIFICATION_SESSIONS_OLD_BASE_PATH
 import de.bund.digitalservice.useid.tenant.MANAGE_IDENTIFICATION_SESSION_AUTHORITY
 import de.bund.digitalservice.useid.tenant.ResolveTenantFilter
 import de.bund.digitalservice.useid.tenant.TenantAuthenticationFilter
@@ -25,12 +26,14 @@ class SecurityConfig(
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http.authorizeHttpRequests()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_BASE_PATH/*/tc-token").permitAll()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_BASE_PATH/*/tokens/*").permitAll()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_BASE_PATH/*/tokens").permitAll()
-            .requestMatchers(HttpMethod.GET, "$IDENTIFICATION_SESSIONS_BASE_PATH/*/transaction-info").permitAll()
+            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/tc-token").permitAll()
+            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/tokens/*").permitAll()
+            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/tokens").permitAll()
+            .requestMatchers(HttpMethod.GET, "$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/transaction-info").permitAll()
             .requestMatchers("$IDENTIFICATION_SESSIONS_BASE_PATH/**").authenticated()
             .requestMatchers("$IDENTIFICATION_SESSIONS_BASE_PATH/**").hasAuthority(MANAGE_IDENTIFICATION_SESSION_AUTHORITY)
+            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/**").authenticated()
+            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/**").hasAuthority(MANAGE_IDENTIFICATION_SESSION_AUTHORITY)
             .anyRequest().permitAll()
             .and().csrf().disable()
             .headers()

--- a/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityConfig.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/config/SecurityConfig.kt
@@ -1,7 +1,7 @@
 package de.bund.digitalservice.useid.config
 
-import de.bund.digitalservice.useid.identification.IDENTIFICATION_SESSIONS_BASE_PATH
-import de.bund.digitalservice.useid.identification.IDENTIFICATION_SESSIONS_OLD_BASE_PATH
+import de.bund.digitalservice.useid.identification.IDENTIFICATIONS_BASE_PATH
+import de.bund.digitalservice.useid.identification.IDENTIFICATIONS_OLD_BASE_PATH
 import de.bund.digitalservice.useid.tenant.MANAGE_IDENTIFICATION_SESSION_AUTHORITY
 import de.bund.digitalservice.useid.tenant.ResolveTenantFilter
 import de.bund.digitalservice.useid.tenant.TenantAuthenticationFilter
@@ -26,14 +26,14 @@ class SecurityConfig(
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http.authorizeHttpRequests()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/tc-token").permitAll()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/tokens/*").permitAll()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/tokens").permitAll()
-            .requestMatchers(HttpMethod.GET, "$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/*/transaction-info").permitAll()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_BASE_PATH/**").authenticated()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_BASE_PATH/**").hasAuthority(MANAGE_IDENTIFICATION_SESSION_AUTHORITY)
-            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/**").authenticated()
-            .requestMatchers("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/**").hasAuthority(MANAGE_IDENTIFICATION_SESSION_AUTHORITY)
+            .requestMatchers("$IDENTIFICATIONS_OLD_BASE_PATH/*/tc-token").permitAll()
+            .requestMatchers("$IDENTIFICATIONS_OLD_BASE_PATH/*/tokens/*").permitAll()
+            .requestMatchers("$IDENTIFICATIONS_OLD_BASE_PATH/*/tokens").permitAll()
+            .requestMatchers(HttpMethod.GET, "$IDENTIFICATIONS_OLD_BASE_PATH/*/transaction-info").permitAll()
+            .requestMatchers("$IDENTIFICATIONS_BASE_PATH/**").authenticated()
+            .requestMatchers("$IDENTIFICATIONS_BASE_PATH/**").hasAuthority(MANAGE_IDENTIFICATION_SESSION_AUTHORITY)
+            .requestMatchers("$IDENTIFICATIONS_OLD_BASE_PATH/**").authenticated()
+            .requestMatchers("$IDENTIFICATIONS_OLD_BASE_PATH/**").hasAuthority(MANAGE_IDENTIFICATION_SESSION_AUTHORITY)
             .anyRequest().permitAll()
             .and().csrf().disable()
             .headers()

--- a/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionController.kt
@@ -22,8 +22,8 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-internal const val IDENTIFICATION_SESSIONS_BASE_PATH = "/api/v1/identifications"
-internal const val IDENTIFICATION_SESSIONS_OLD_BASE_PATH = "/api/v1/identification/sessions"
+internal const val IDENTIFICATIONS_BASE_PATH = "/api/v1/identifications"
+internal const val IDENTIFICATIONS_OLD_BASE_PATH = "/api/v1/identification/sessions"
 internal const val TCTOKEN_PATH_SUFFIX = "tc-token"
 
 @RestController
@@ -42,7 +42,7 @@ internal const val TCTOKEN_PATH_SUFFIX = "tc-token"
 )
 class IdentificationSessionsController(private val identificationSessionService: IdentificationSessionService) {
 
-    @PostMapping(IDENTIFICATION_SESSIONS_BASE_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping(IDENTIFICATIONS_BASE_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Start session for a new identification as eService")
     @ApiResponse(responseCode = "200")
     @ApiResponse(
@@ -63,7 +63,7 @@ class IdentificationSessionsController(private val identificationSessionService:
             .body(CreateIdentificationSessionResponse(tcTokenUrl))
     }
 
-    @PostMapping(IDENTIFICATION_SESSIONS_OLD_BASE_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping(IDENTIFICATIONS_OLD_BASE_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Start session for a new identification as eService")
     @ApiResponse(responseCode = "200")
     @ApiResponse(
@@ -79,7 +79,7 @@ class IdentificationSessionsController(private val identificationSessionService:
     }
 
     @GetMapping(
-        path = ["$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/{useIdSessionId}/$TCTOKEN_PATH_SUFFIX"],
+        path = ["$IDENTIFICATIONS_OLD_BASE_PATH/{useIdSessionId}/$TCTOKEN_PATH_SUFFIX"],
         produces = [MediaType.APPLICATION_XML_VALUE],
     )
     @Operation(summary = "Get TC token for this session")
@@ -97,7 +97,7 @@ class IdentificationSessionsController(private val identificationSessionService:
             .body(JakartaTCToken.fromTCTokenType(tcToken))
     }
 
-    @GetMapping("$IDENTIFICATION_SESSIONS_BASE_PATH/{eIdSessionId}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("$IDENTIFICATIONS_BASE_PATH/{eIdSessionId}", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Fetch data as eService after identification was successful")
     @ApiResponse(responseCode = "200")
     @ApiResponse(
@@ -132,7 +132,7 @@ class IdentificationSessionsController(private val identificationSessionService:
         }
     }
 
-    @GetMapping("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/{eIdSessionId}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("$IDENTIFICATIONS_OLD_BASE_PATH/{eIdSessionId}", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Fetch data as eService after identification was successful")
     @ApiResponse(responseCode = "200")
     @ApiResponse(

--- a/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionController.kt
@@ -19,16 +19,15 @@ import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-internal const val IDENTIFICATION_SESSIONS_BASE_PATH = "/api/v1/identification/sessions"
+internal const val IDENTIFICATION_SESSIONS_BASE_PATH = "/api/v1/identifications"
+internal const val IDENTIFICATION_SESSIONS_OLD_BASE_PATH = "/api/v1/identification/sessions"
 internal const val TCTOKEN_PATH_SUFFIX = "tc-token"
 
 @RestController
 @Timed
-@RequestMapping(IDENTIFICATION_SESSIONS_BASE_PATH)
 @Tag(
     name = "Identification Sessions",
     description = "An identification session represent an ongoing identification flow of a user and stores the required information.",
@@ -43,7 +42,7 @@ internal const val TCTOKEN_PATH_SUFFIX = "tc-token"
 )
 class IdentificationSessionsController(private val identificationSessionService: IdentificationSessionService) {
 
-    @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping(IDENTIFICATION_SESSIONS_BASE_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Start session for a new identification as eService")
     @ApiResponse(responseCode = "200")
     @ApiResponse(
@@ -64,8 +63,23 @@ class IdentificationSessionsController(private val identificationSessionService:
             .body(CreateIdentificationSessionResponse(tcTokenUrl))
     }
 
+    @PostMapping(IDENTIFICATION_SESSIONS_OLD_BASE_PATH, produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Start session for a new identification as eService")
+    @ApiResponse(responseCode = "200")
+    @ApiResponse(
+        responseCode = "401",
+        description = "Authentication failed (missing or wrong api key)",
+        content = [Content()],
+    )
+    @SecurityRequirement(name = "apiKey")
+    fun startSessionOld(
+        authentication: Authentication,
+    ): ResponseEntity<CreateIdentificationSessionResponse> {
+        return startSession(authentication)
+    }
+
     @GetMapping(
-        path = ["/{useIdSessionId}/$TCTOKEN_PATH_SUFFIX"],
+        path = ["$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/{useIdSessionId}/$TCTOKEN_PATH_SUFFIX"],
         produces = [MediaType.APPLICATION_XML_VALUE],
     )
     @Operation(summary = "Get TC token for this session")
@@ -83,7 +97,7 @@ class IdentificationSessionsController(private val identificationSessionService:
             .body(JakartaTCToken.fromTCTokenType(tcToken))
     }
 
-    @GetMapping("/{eIdSessionId}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @GetMapping("$IDENTIFICATION_SESSIONS_BASE_PATH/{eIdSessionId}", produces = [MediaType.APPLICATION_JSON_VALUE])
     @Operation(summary = "Fetch data as eService after identification was successful")
     @ApiResponse(responseCode = "200")
     @ApiResponse(
@@ -116,5 +130,26 @@ class IdentificationSessionsController(private val identificationSessionService:
         if (tenant.id != identificationSession.tenantId) {
             throw InvalidTenantException("Tenant does not match with tenant used to start the session.")
         }
+    }
+
+    @GetMapping("$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/{eIdSessionId}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    @Operation(summary = "Fetch data as eService after identification was successful")
+    @ApiResponse(responseCode = "200")
+    @ApiResponse(
+        responseCode = "404",
+        description = "No corresponding session found for that eIdSessionId",
+        content = [Content()],
+    )
+    @ApiResponse(
+        responseCode = "401",
+        description = "Authentication failed (missing or wrong api key)",
+        content = [Content()],
+    )
+    @SecurityRequirement(name = "apiKey")
+    fun getIdentityOld(
+        @PathVariable eIdSessionId: UUID,
+        authentication: Authentication,
+    ): ResponseEntity<GetResultResponseType> {
+        return getIdentity(eIdSessionId, authentication)
     }
 }

--- a/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionService.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionService.kt
@@ -41,7 +41,7 @@ class IdentificationSessionService(
     }
 
     private fun buildTcTokenUrl(session: IdentificationSession): String {
-        return "${applicationProperties.baseUrl}$IDENTIFICATION_SESSIONS_BASE_PATH/${session.useIdSessionId}/$TCTOKEN_PATH_SUFFIX"
+        return "${applicationProperties.baseUrl}$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/${session.useIdSessionId}/$TCTOKEN_PATH_SUFFIX"
     }
 
     fun startSessionWithEIdServer(useIdSessionId: UUID): TCTokenType {

--- a/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionService.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionService.kt
@@ -41,7 +41,7 @@ class IdentificationSessionService(
     }
 
     private fun buildTcTokenUrl(session: IdentificationSession): String {
-        return "${applicationProperties.baseUrl}$IDENTIFICATION_SESSIONS_OLD_BASE_PATH/${session.useIdSessionId}/$TCTOKEN_PATH_SUFFIX"
+        return "${applicationProperties.baseUrl}$IDENTIFICATIONS_OLD_BASE_PATH/${session.useIdSessionId}/$TCTOKEN_PATH_SUFFIX"
     }
 
     fun startSessionWithEIdServer(useIdSessionId: UUID): TCTokenType {

--- a/src/main/kotlin/de/bund/digitalservice/useid/timebasedtokens/TimeBasedTokenController.kt
+++ b/src/main/kotlin/de/bund/digitalservice/useid/timebasedtokens/TimeBasedTokenController.kt
@@ -1,6 +1,6 @@
 package de.bund.digitalservice.useid.timebasedtokens
 
-import de.bund.digitalservice.useid.identification.IDENTIFICATION_SESSIONS_BASE_PATH
+import de.bund.digitalservice.useid.identification.IDENTIFICATIONS_BASE_PATH
 import io.micrometer.core.annotation.Timed
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
@@ -19,7 +19,7 @@ import java.util.UUID
 
 @RestController
 @Timed
-@RequestMapping(IDENTIFICATION_SESSIONS_BASE_PATH)
+@RequestMapping(IDENTIFICATIONS_BASE_PATH)
 @Tag(name = "Time-based Tokens", description = "Time-based tokens inside the widget that are only 60 seconds valid and can be checked by the app.")
 @ConditionalOnProperty(name = ["features.desktop-solution-enabled"], havingValue = "true")
 class TimeBasedTokenController(private val timeBasedTokenService: TimeBasedTokenService) {

--- a/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
@@ -35,10 +35,20 @@ import java.util.UUID
 
 private const val AUTHORIZATION_HEADER = "Bearer valid-api-key-1"
 private const val REFRESH_ADDRESS = "valid-refresh-address-1"
+const val TEST_IDENTIFICATION_SESSIONS_BASE_PATH = "api/v1/identifications"
+const val TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH = "api/v1/identification/sessions"
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Tag("integration")
 class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClient: WebTestClient) {
+    fun getIdentificationPath(forOldApi: Boolean = false): String {
+        return if (forOldApi) {
+            "${applicationProperties.baseUrl}/$TEST_IDENTIFICATION_SESSIONS_BASE_PATH"
+        } else {
+            "${applicationProperties.baseUrl}/$TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH"
+        }
+    }
+
     val attributes = listOf("DG1", "DG2")
 
     @Autowired
@@ -70,13 +80,38 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
         assertThat(session.requestDataGroups, `is`(attributes))
         assertThat(session.refreshAddress, `is`(REFRESH_ADDRESS))
 
-        val expectedTcTokenURL = "${applicationProperties.baseUrl}/api/v1/identifications/sessions/${session.useIdSessionId}/tc-token"
+        val expectedTcTokenURL = "${getIdentificationPath(forOldApi = true)}/${session.useIdSessionId}/tc-token"
         assertEquals(expectedTcTokenURL, tcTokenURL)
     }
 
     @Test
     fun `start session endpoint returns 403 when no authorization header was passed`() {
         sendGETRequest(IDENTIFICATION_SESSIONS_BASE_PATH).exchange().expectStatus().isForbidden
+    }
+
+    @Test
+    fun `old start session endpoint returns TCTokenUrl`() {
+        var tcTokenURL = ""
+
+        sendStartSessionRequest()
+            .expectStatus().isOk
+            .expectHeader().contentType(MediaType.APPLICATION_JSON_VALUE)
+            .expectBody().jsonPath("$.tcTokenUrl").value<String> { tcTokenURL = it }
+
+        val useIdSessionId = extractUseIdSessionIdFromTcTokenUrl(tcTokenURL)
+        val session = retrieveIdentificationSession(useIdSessionId)!!
+        assertThat(session.eIdSessionId, nullValue())
+        assertThat(session.useIdSessionId, notNullValue())
+        assertThat(session.requestDataGroups, `is`(attributes))
+        assertThat(session.refreshAddress, `is`(REFRESH_ADDRESS))
+
+        val expectedTcTokenURL = "${getIdentificationPath(forOldApi = true)}/${session.useIdSessionId}/tc-token"
+        assertEquals(expectedTcTokenURL, tcTokenURL)
+    }
+
+    @Test
+    fun `old start session endpoint returns 403 when no authorization header was passed`() {
+        sendGETRequest(getIdentificationPath()).exchange().expectStatus().isForbidden
     }
 
     @Test
@@ -105,13 +140,13 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
     @Test
     fun `tcToken endpoint returns 400 when passed an invalid UUID as useIdSessionID`() {
         val invalidId = "IamInvalid"
-        sendGETRequest("/api/v1/identifications/sessions/$invalidId/tc-token").exchange().expectStatus().isBadRequest
+        sendGETRequest("${getIdentificationPath(forOldApi = true)}/$invalidId/tc-token").exchange().expectStatus().isBadRequest
     }
 
     @Test
     fun `tcToken endpoint returns 404 when passed a unknown UUID as useIdSessionID`() {
         val unknownId = UUID.randomUUID()
-        sendGETRequest("/api/v1/identifications/sessions/$unknownId/tc-token").exchange().expectStatus().isNotFound
+        sendGETRequest("${getIdentificationPath(forOldApi = true)}/$unknownId/tc-token").exchange().expectStatus().isNotFound
     }
 
     @Test
@@ -185,7 +220,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
         var tcTokenURL = ""
         webTestClient
             .post()
-            .uri("/api/v1/identifications")
+            .uri(getIdentificationPath())
             .headers {
                 it.set(HttpHeaders.AUTHORIZATION, "Bearer valid-api-key-2")
             }
@@ -203,12 +238,97 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     @Test
     fun `identity data endpoint returns 403 when no authorization header was passed`() {
-        sendGETRequest("/api/v1/identifications/sessions/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
+        sendGETRequest("${getIdentificationPath()}/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
     }
 
     @Test
     fun `identity data endpoint returns 404 when passed a random UUID`() {
         sendIdentityRequest(UUID.randomUUID().toString())
+            .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `old identity data endpoint returns valid personal data and removes identification session from database`() {
+        val eIdSessionId = UUID.randomUUID().toString()
+        mockTcToken("https://www.foobar.com?sessionId=$eIdSessionId")
+
+        var tcTokenURL = ""
+        sendStartSessionRequestToOldEndpoint()
+            .expectStatus().isOk
+            .expectBody().jsonPath("$.tcTokenUrl").value<String> { tcTokenURL = it }
+
+        sendGETRequest(extractRelativePathFromURL(tcTokenURL))
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().xpath("TCTokenType").exists()
+
+        val mockResult = Result()
+        mockResult.resultMajor = "http://www.bsi.bund.de/ecard/api/1.1/resultmajor#ok"
+        val personalData = PersonalDataType()
+        personalData.givenNames = "Ben"
+        val mockGetResultResponseType = mockk<GetResultResponseType>()
+        every { mockGetResultResponseType.personalData } returns personalData
+        every { mockGetResultResponseType.fulfilsAgeVerification } returns VerificationResultType()
+        every { mockGetResultResponseType.fulfilsPlaceVerification } returns VerificationResultType()
+        every { mockGetResultResponseType.operationsAllowedByUser } returns OperationsResponderType()
+        every { mockGetResultResponseType.transactionAttestationResponse } returns TransactionAttestationResponseType()
+        every { mockGetResultResponseType.levelOfAssuranceResult } returns LevelOfAssuranceType.HTTP_EIDAS_EUROPA_EU_LO_A_LOW
+        every { mockGetResultResponseType.result } returns mockResult
+        every { anyConstructed<EidService>().getEidInformation(any()) } returns mockGetResultResponseType
+
+        sendIdentityRequestToOldEndpoint(eIdSessionId)
+            .expectStatus().isOk
+            .expectHeader().contentType(MediaType.APPLICATION_JSON_VALUE)
+            .expectBody()
+            .jsonPath("$.result").value<LinkedHashMap<String, String>> {
+                assertEquals(it["resultMajor"], mockResult.resultMajor)
+            }
+            .jsonPath("$.personalData").value<LinkedHashMap<String, String>> {
+                assertEquals(it["givenNames"], personalData.givenNames)
+            }
+
+        val useIdSessionId = extractUseIdSessionIdFromTcTokenUrl(tcTokenURL)
+        await().until { retrieveIdentificationSession(useIdSessionId) == null }
+    }
+
+    @Test
+    fun `old identity data endpoint returns 400 when passed an invalid string instead of UUID`() {
+        sendIdentityRequestToOldEndpoint("IamInvalid")
+            .expectStatus().isBadRequest
+    }
+
+    @Test
+    fun `old identity data endpoint returns 401 when api key differs from the api key used to create the session`() {
+        val eIdSessionId = UUID.randomUUID().toString()
+        mockTcToken("https://www.foobar.com?sessionId=$eIdSessionId")
+
+        var tcTokenURL = ""
+        webTestClient
+            .post()
+            .uri(TEST_IDENTIFICATION_SESSIONS_BASE_PATH)
+            .headers {
+                it.set(HttpHeaders.AUTHORIZATION, "Bearer valid-api-key-2")
+            }
+            .exchange()
+            .expectStatus().isOk
+            .expectBody().jsonPath("$.tcTokenUrl").value<String> { tcTokenURL = it }
+
+        sendGETRequest(extractRelativePathFromURL(tcTokenURL))
+            .exchange()
+            .expectStatus().isOk
+
+        sendIdentityRequestToOldEndpoint(eIdSessionId)
+            .expectStatus().isUnauthorized
+    }
+
+    @Test
+    fun `old identity data endpoint returns 403 when no authorization header was passed`() {
+        sendGETRequest("${getIdentificationPath(forOldApi = true)}/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
+    }
+
+    @Test
+    fun `old identity data endpoint returns 404 when passed a random UUID`() {
+        sendIdentityRequestToOldEndpoint(UUID.randomUUID().toString())
             .expectStatus().isNotFound
     }
 
@@ -219,7 +339,12 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
     }
 
     private fun sendIdentityRequest(eIdSessionId: String) =
-        sendGETRequest("/api/v1/identifications/$eIdSessionId")
+        sendGETRequest("${getIdentificationPath()}/$eIdSessionId")
+            .headers { setAuthorizationHeader(it) }
+            .exchange()
+
+    private fun sendIdentityRequestToOldEndpoint(eIdSessionId: String) =
+        sendGETRequest("${getIdentificationPath(forOldApi = true)}/$eIdSessionId")
             .headers { setAuthorizationHeader(it) }
             .exchange()
 
@@ -231,7 +356,13 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     private fun sendStartSessionRequest() = webTestClient
         .post()
-        .uri("/api/v1/identifications")
+        .uri(getIdentificationPath())
+        .headers { setAuthorizationHeader(it) }
+        .exchange()
+
+    private fun sendStartSessionRequestToOldEndpoint() = webTestClient
+        .post()
+        .uri(getIdentificationPath(forOldApi = true))
         .headers { setAuthorizationHeader(it) }
         .exchange()
 

--- a/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
@@ -43,9 +43,9 @@ const val TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH = "api/v1/identification/se
 class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClient: WebTestClient) {
     fun getIdentificationPath(forOldApi: Boolean = false): String {
         return if (forOldApi) {
-            "${applicationProperties.baseUrl}/$TEST_IDENTIFICATION_SESSIONS_BASE_PATH"
-        } else {
             "${applicationProperties.baseUrl}/$TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH"
+        } else {
+            "${applicationProperties.baseUrl}/$TEST_IDENTIFICATION_SESSIONS_BASE_PATH"
         }
     }
 
@@ -106,12 +106,13 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
         assertThat(session.refreshAddress, `is`(REFRESH_ADDRESS))
 
         val expectedTcTokenURL = "${getIdentificationPath(forOldApi = true)}/${session.useIdSessionId}/tc-token"
+        println(expectedTcTokenURL)
         assertEquals(expectedTcTokenURL, tcTokenURL)
     }
 
     @Test
     fun `old start session endpoint returns 403 when no authorization header was passed`() {
-        sendGETRequest(getIdentificationPath()).exchange().expectStatus().isForbidden
+        sendGETRequest(TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH).exchange().expectStatus().isForbidden
     }
 
     @Test
@@ -140,13 +141,13 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
     @Test
     fun `tcToken endpoint returns 400 when passed an invalid UUID as useIdSessionID`() {
         val invalidId = "IamInvalid"
-        sendGETRequest("${getIdentificationPath(forOldApi = true)}/$invalidId/tc-token").exchange().expectStatus().isBadRequest
+        sendGETRequest("$TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH/$invalidId/tc-token").exchange().expectStatus().isBadRequest
     }
 
     @Test
     fun `tcToken endpoint returns 404 when passed a unknown UUID as useIdSessionID`() {
         val unknownId = UUID.randomUUID()
-        sendGETRequest("${getIdentificationPath(forOldApi = true)}/$unknownId/tc-token").exchange().expectStatus().isNotFound
+        sendGETRequest("$TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH/$unknownId/tc-token").exchange().expectStatus().isNotFound
     }
 
     @Test
@@ -220,7 +221,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
         var tcTokenURL = ""
         webTestClient
             .post()
-            .uri(getIdentificationPath())
+            .uri(TEST_IDENTIFICATION_SESSIONS_BASE_PATH)
             .headers {
                 it.set(HttpHeaders.AUTHORIZATION, "Bearer valid-api-key-2")
             }
@@ -238,7 +239,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     @Test
     fun `identity data endpoint returns 403 when no authorization header was passed`() {
-        sendGETRequest("${getIdentificationPath()}/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
+        sendGETRequest("$TEST_IDENTIFICATION_SESSIONS_BASE_PATH/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
     }
 
     @Test
@@ -323,7 +324,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     @Test
     fun `old identity data endpoint returns 403 when no authorization header was passed`() {
-        sendGETRequest("${getIdentificationPath(forOldApi = true)}/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
+        sendGETRequest("$TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
     }
 
     @Test
@@ -339,12 +340,12 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
     }
 
     private fun sendIdentityRequest(eIdSessionId: String) =
-        sendGETRequest("${getIdentificationPath()}/$eIdSessionId")
+        sendGETRequest("$TEST_IDENTIFICATION_SESSIONS_BASE_PATH/$eIdSessionId")
             .headers { setAuthorizationHeader(it) }
             .exchange()
 
     private fun sendIdentityRequestToOldEndpoint(eIdSessionId: String) =
-        sendGETRequest("${getIdentificationPath(forOldApi = true)}/$eIdSessionId")
+        sendGETRequest("$TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH/$eIdSessionId")
             .headers { setAuthorizationHeader(it) }
             .exchange()
 
@@ -356,13 +357,13 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     private fun sendStartSessionRequest() = webTestClient
         .post()
-        .uri(getIdentificationPath())
+        .uri(TEST_IDENTIFICATION_SESSIONS_BASE_PATH)
         .headers { setAuthorizationHeader(it) }
         .exchange()
 
     private fun sendStartSessionRequestToOldEndpoint() = webTestClient
         .post()
-        .uri(getIdentificationPath(forOldApi = true))
+        .uri(TEST_IDENTIFICATION_SESSIONS_OLD_BASE_PATH)
         .headers { setAuthorizationHeader(it) }
         .exchange()
 

--- a/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
@@ -70,7 +70,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
         assertThat(session.requestDataGroups, `is`(attributes))
         assertThat(session.refreshAddress, `is`(REFRESH_ADDRESS))
 
-        val expectedTcTokenURL = "${applicationProperties.baseUrl}/api/v1/identification/sessions/${session.useIdSessionId}/tc-token"
+        val expectedTcTokenURL = "${applicationProperties.baseUrl}/api/v1/identifications/sessions/${session.useIdSessionId}/tc-token"
         assertEquals(expectedTcTokenURL, tcTokenURL)
     }
 
@@ -105,13 +105,13 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
     @Test
     fun `tcToken endpoint returns 400 when passed an invalid UUID as useIdSessionID`() {
         val invalidId = "IamInvalid"
-        sendGETRequest("/api/v1/identification/sessions/$invalidId/tc-token").exchange().expectStatus().isBadRequest
+        sendGETRequest("/api/v1/identifications/sessions/$invalidId/tc-token").exchange().expectStatus().isBadRequest
     }
 
     @Test
     fun `tcToken endpoint returns 404 when passed a unknown UUID as useIdSessionID`() {
         val unknownId = UUID.randomUUID()
-        sendGETRequest("/api/v1/identification/sessions/$unknownId/tc-token").exchange().expectStatus().isNotFound
+        sendGETRequest("/api/v1/identifications/sessions/$unknownId/tc-token").exchange().expectStatus().isNotFound
     }
 
     @Test
@@ -185,7 +185,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
         var tcTokenURL = ""
         webTestClient
             .post()
-            .uri("/api/v1/identification/sessions")
+            .uri("/api/v1/identifications")
             .headers {
                 it.set(HttpHeaders.AUTHORIZATION, "Bearer valid-api-key-2")
             }
@@ -203,7 +203,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     @Test
     fun `identity data endpoint returns 403 when no authorization header was passed`() {
-        sendGETRequest("/api/v1/identification/sessions/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
+        sendGETRequest("/api/v1/identifications/sessions/${UUID.randomUUID()}").exchange().expectStatus().isForbidden
     }
 
     @Test
@@ -219,7 +219,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
     }
 
     private fun sendIdentityRequest(eIdSessionId: String) =
-        sendGETRequest("/api/v1/identification/sessions/$eIdSessionId")
+        sendGETRequest("/api/v1/identifications/$eIdSessionId")
             .headers { setAuthorizationHeader(it) }
             .exchange()
 
@@ -231,7 +231,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     private fun sendStartSessionRequest() = webTestClient
         .post()
-        .uri("/api/v1/identification/sessions")
+        .uri("/api/v1/identifications")
         .headers { setAuthorizationHeader(it) }
         .exchange()
 

--- a/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
+++ b/src/test/kotlin/de/bund/digitalservice/useid/identification/IdentificationSessionControllerIntegrationTest.kt
@@ -86,7 +86,7 @@ class IdentificationSessionControllerIntegrationTest(@Autowired val webTestClien
 
     @Test
     fun `start session endpoint returns 403 when no authorization header was passed`() {
-        sendGETRequest(IDENTIFICATION_SESSIONS_BASE_PATH).exchange().expectStatus().isForbidden
+        sendGETRequest(IDENTIFICATIONS_BASE_PATH).exchange().expectStatus().isForbidden
     }
 
     @Test


### PR DESCRIPTION
This should adapt the API endpoints for the identification to our new [design](https://digitalservicebund.atlassian.net/wiki/spaces/UseID/pages/628392825/API+Design). For the transition period the old endpoints are kept. For this, I have duplicated the tests, too.

I will push the needed changes for our SDK. Other open tasks will be:
- [x] Add changes to SDK (s. this [PR](https://github.com/digitalservicebund/useid-eservice-sdk/pull/26))
- [ ] Support usage of SDK by services that use our backend
- [ ] Delete the old endpoints

# Feedback
- Is there anything I am missing? 
- Do you have a better idea than the function to provide the application properties to generate the URL for testing