### PR TITLE
USEID-835: Change port of local database to non-default

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=secret
       - POSTGRES_DB=useid
     ports:
-      - '5432:5432'
+      - '5433:5432'
     volumes:
       - db:/var/lib/postgresql/data
 volumes:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -34,7 +34,7 @@ eidservice:
 spring:
   datasource:
     driverClassName: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/useid
+    url: jdbc:postgresql://localhost:5433/useid
     username: root
     password: secret
 


### PR DESCRIPTION
Am I missing something? Imo the testing container does not need to be changed because the port is set automatically.